### PR TITLE
Remove many type annotations and generalize acceptable types

### DIFF
--- a/src/NMF.jl
+++ b/src/NMF.jl
@@ -1,10 +1,10 @@
 module NMF
 
-	using ArrayViews
-	using MLBase
-	import Base: sum!
+    using ArrayViews
+    using MLBase
+    import Base: sum!
 
-	export nnmf
+    export nnmf
 
     include("common.jl")
     include("utils.jl")

--- a/src/common.jl
+++ b/src/common.jl
@@ -2,7 +2,7 @@
 
 # tools to check size
 
-function nmf_checksize(X::AbstractMatrix, 
+function nmf_checksize(X,
                        W::AbstractMatrix, 
                        H::AbstractMatrix)
 
@@ -19,15 +19,15 @@ end
 
 # the result type
 
-immutable Result
-    W::Matrix{Float64}
-    H::Matrix{Float64}
+immutable Result{T}
+    W::Matrix{T}
+    H::Matrix{T}
     niters::Int
     converged::Bool
-    objvalue::Float64
+    objvalue::T
 
-    function Result(W::Matrix{Float64}, H::Matrix{Float64}, 
-                       niters::Int, converged::Bool, objv::Float64)
+    function Result(W::Matrix{T}, H::Matrix{T},
+                       niters::Int, converged::Bool, objv)
 
         size(W, 2) == size(H, 1) || 
             throw(DimensionMismatch("Inner dimensions of W and H mismatch."))
@@ -37,17 +37,17 @@ end
 
 # common algorithmic skeleton for iterative updating methods
 
-abstract NMFUpdater
+abstract NMFUpdater{T}
 
-function nmf_skeleton!(updater::NMFUpdater,
-                       X::Matrix{Float64}, W::Matrix{Float64}, H::Matrix{Float64}, 
-                       maxiter::Int, verbose::Bool, tol::Float64)
-    objv = NaN
+function nmf_skeleton!{T}(updater::NMFUpdater{T},
+                          X, W::Matrix{T}, H::Matrix{T},
+                          maxiter::Int, verbose::Bool, tol)
+    objv = convert(T, NaN)
 
     # init
     state = prepare_state(updater, X, W, H)
-    preW = Array(Float64, size(W))
-    preH = Array(Float64, size(H))
+    preW = Array(T, size(W))
+    preH = Array(T, size(H))
     if verbose
         objv = evaluate_objv(updater, state, X, W, H)
         @printf("%-5s     %-13s    %-13s    %-13s\n", "Iter", "objv", "objv.change", "(W & H).change")
@@ -83,7 +83,7 @@ function nmf_skeleton!(updater::NMFUpdater,
     if !verbose
         objv = evaluate_objv(updater, state, X, W, H)
     end
-    return Result(W, H, t, converged, objv)
+    return Result{T}(W, H, t, converged, objv)
 end
 
 

--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -1,16 +1,17 @@
 
 # random initialization
 
-function randinit(X::Matrix{Float64}, k::Integer; normalize::Bool=false, zeroh::Bool=false)
+function randinit(X, k::Integer; normalize::Bool=false, zeroh::Bool=false)
     p, n = size(X)
+    T = eltype(X)
 
-    W = rand(p, k)
+    W = rand(T, p, k)
     if normalize
         normalize1_cols!(W)
     end
 
-    H = zeroh ? zeros(k, n) : rand(k, n)
-    return (W, H)::(Matrix{Float64}, Matrix{Float64})
+    H = zeroh ? zeros(T, k, n) : rand(T, k, n)
+    return W, H
 end
 
 
@@ -21,21 +22,22 @@ end
 #   C. Boutsidis, and E. Gallopoulos. SVD based initialization: A head
 #   start for nonnegative matrix factorization. Pattern Recognition, 2007.
 #  
-function _nndsvd!(X::Matrix{Float64}, 
-                  W::ContiguousMatrix{Float64}, 
-                  Ht::ContiguousMatrix{Float64},
+function _nndsvd!(X,
+                  W,
+                  Ht,
                   inith::Bool, 
                   variant::Int)
 
     p, n = size(X)
     k = size(W, 2)
+    T = eltype(W)
 
     # compute SVD
     (U, s, V) = svd(X, thin=true)
 
     # main loop
-    v0::Float64 = variant == 0 ? 0.0 :
-                  variant == 1 ? mean(X) : mean(X) * 0.01
+    v0 = variant == 0 ? zero(T) :
+         variant == 1 ? convert(T, mean(X)) : convert(T, mean(X) * 0.01)
 
     for j = 1:k
         x = view(U,:,j)
@@ -47,46 +49,47 @@ function _nndsvd!(X::Matrix{Float64},
 
         vj = v0
         if variant == 2
-            vj *= rand()
+            vj *= rand(T)
         end
 
         if inith
             if mp >= mn
-                scalepos!(view(W,:,j), x, 1.0 / xpnrm, vj)
+                scalepos!(view(W,:,j), x, 1 / xpnrm, vj)
                 scalepos!(view(Ht,:,j), y, s[j] * mp / ypnrm, vj)
             else
                 ss = sqrt(s[j] * mn)
-                scaleneg!(view(W,:,j), x, 1.0 / xnnrm, vj)
+                scaleneg!(view(W,:,j), x, 1 / xnnrm, vj)
                 scaleneg!(view(Ht,:,j), y, s[j] * mn / ynnrm, vj)
             end            
         else
             if mp >= mn
-                scalepos!(view(W,:,j), x, 1.0 / xpnrm, vj)
+                scalepos!(view(W,:,j), x, 1 / xpnrm, vj)
             else
-                scaleneg!(view(W,:,j), x, 1.0 / xnnrm, vj)
+                scaleneg!(view(W,:,j), x, 1 / xnnrm, vj)
             end
         end
     end
 end
 
-function nndsvd(X::Matrix{Float64}, k::Integer; 
+function nndsvd(X, k::Integer;
                 zeroh::Bool=false, 
                 variant::Symbol=:std)
 
     p, n = size(X)
+    T = eltype(X)
     ivar = variant == :std ? 0 :
            variant == :a   ? 1 :
            variant == :ar  ? 2 :
            error("Invalid value for variant")
 
-    W = Array(Float64, p, k)
-    H = Array(Float64, k, n)
+    W = Array(T, p, k)
+    H = Array(T, k, n)
     if zeroh
         Ht = contiguous_view(H, (n, k))
         _nndsvd!(X, W, Ht, false, ivar)
-        fill!(H, 0.0)
+        fill!(H, 0)
     else
-        Ht = Array(Float64, n, k)
+        Ht = Array(T, n, k)
         _nndsvd!(X, W, Ht, true, ivar)
         for j = 1:k
             for i = 1:n
@@ -94,27 +97,27 @@ function nndsvd(X::Matrix{Float64}, k::Integer;
             end
         end
     end
-    return (W, H)::(Matrix{Float64}, Matrix{Float64})
+    return (W, H)
 end
 
-function posnegnorm(x::ContiguousArray{Float64})
-    pn = 0.0
-    nn = 0.0
+function posnegnorm{T}(x::AbstractArray{T})
+    pn = zero(T)
+    nn = zero(T)
     for i = 1:length(x)
         @inbounds xi = x[i]
-        if xi > 0.0
+        if xi > zero(T)
             pn += abs2(xi)
         else
             nn += abs2(xi)
         end
     end
-    return (sqrt(pn), sqrt(nn))::(Float64, Float64)
+    return (sqrt(pn), sqrt(nn))
 end
 
-function scalepos!(y::ContiguousArray{Float64}, x::ContiguousArray{Float64}, c::Float64, v0::Float64)
+function scalepos!{T<:Number}(y, x, c::T, v0::T)
     @inbounds for i = 1:length(y)
         xi = x[i]
-        if xi > 0.0
+        if xi > zero(T)
             y[i] = xi * c
         else
             y[i] = v0
@@ -122,10 +125,10 @@ function scalepos!(y::ContiguousArray{Float64}, x::ContiguousArray{Float64}, c::
     end
 end
 
-function scaleneg!(y::ContiguousArray{Float64}, x::ContiguousArray{Float64}, c::Float64, v0::Float64)
+function scaleneg!{T<:Number}(y, x, c::T, v0::T)
     @inbounds for i = 1:length(y)
         xi = x[i]
-        if xi < 0.0
+        if xi < zero(T)
             y[i] = - (xi * c)
         else
             y[i] = v0

--- a/src/interf.jl
+++ b/src/interf.jl
@@ -1,11 +1,11 @@
 # Interface function: nnmf
 
-function nnmf(X::Matrix{Float64}, k::Integer; 
-              init::Symbol=:nndsvdar, 
-              alg::Symbol=:alspgrad, 
-              maxiter::Integer=100,
-              tol::Real=1.0e-6, 
-              verbose::Bool=false)
+function nnmf{T}(X::AbstractMatrix{T}, k::Integer;
+                 init::Symbol=:nndsvdar,
+                 alg::Symbol=:alspgrad,
+                 maxiter::Integer=100,
+                 tol::Real=cbrt(eps(T)/100),
+                 verbose::Bool=false)
 
     p, n = size(X)
     k <= min(p, n) || error("The value of k should not exceed min(size(X)).")
@@ -32,10 +32,10 @@ function nnmf(X::Matrix{Float64}, k::Integer;
 
     # choose algorithm
     alginst = 
-        alg == :projals ? ProjectedALS(maxiter=maxiter, tol=tol, verbose=verbose) :
-        alg == :alspgrad ? ALSPGrad(maxiter=maxiter, tol=tol, verbose=verbose) :
-        alg == :multmse ? MultUpdate(obj=:mse, maxiter=maxiter, tol=tol, verbose=verbose) :
-        alg == :multdiv ? MultUpdate(obj=:div, maxiter=maxiter, tol=tol, verbose=verbose) :
+        alg == :projals ? ProjectedALS{T}(maxiter=maxiter, tol=tol, verbose=verbose) :
+        alg == :alspgrad ? ALSPGrad{T}(maxiter=maxiter, tol=tol, verbose=verbose) :
+        alg == :multmse ? MultUpdate{T}(obj=:mse, maxiter=maxiter, tol=tol, verbose=verbose) :
+        alg == :multdiv ? MultUpdate{T}(obj=:div, maxiter=maxiter, tol=tol, verbose=verbose) :
         error("Invalid algorithm.")
 
     # run optimization

--- a/test/alspgrad.jl
+++ b/test/alspgrad.jl
@@ -11,21 +11,25 @@ p = 5
 n = 8
 k = 3
 
-Wg = max(rand(p, k) .- 0.3, 0.0)
-Hg = max(rand(k, n) .- 0.3, 0.0)
-X = Wg * Hg
+# Matrices
+for T in (Float64, Float32)
+    Wg = max(rand(T, p, k) .- 0.3, 0)
+    Hg = max(rand(T, k, n) .- 0.3, 0)
+    X = Wg * Hg
 
-# test update of H
+    # test update of H
 
-H = rand(k, n)
-NMF.alspgrad_updateh!(X, Wg, H; maxiter=200)
-@test all(H .>= 0.0)
-@test_approx_eq_eps H Hg 1.0e-4
+    H = rand(T, k, n)
+    NMF.alspgrad_updateh!(X, Wg, H; maxiter=200)
+    @test all(H .>= 0.0)
+    @test_approx_eq_eps H Hg eps(T)^(1/4)
 
-# test update of W
+    # test update of W
 
-W = rand(p, k)
-NMF.alspgrad_updatew!(X, W, Hg; maxiter=200)
-@test all(W .>= 0.0)
-@test_approx_eq_eps W Wg 1.0e-4
+    W = rand(T, p, k)
+    NMF.alspgrad_updatew!(X, W, Hg; maxiter=200)
+    @test all(W .>= 0.0)
+    @test_approx_eq_eps W Wg eps(T)^(1/4)
 
+    NMF.solve!(NMF.ALSPGrad{T}(), X, W, H)
+end

--- a/test/alspgrad.jl
+++ b/test/alspgrad.jl
@@ -1,6 +1,6 @@
 # some tests for ALSPGrad
 
-using NMF
+import NMF
 using Base.Test
 
 # data

--- a/test/interf.jl
+++ b/test/interf.jl
@@ -1,0 +1,20 @@
+import NMF
+using Base.Test
+
+srand(5678)
+
+p = 5
+n = 8
+k = 3
+
+for T in (Float64, Float32)
+    Wg = max(rand(T, p, k) .- 0.3, 0)
+    Hg = max(rand(T, k, n) .- 0.3, 0)
+    X = Wg * Hg
+
+    for alg in (:multmse, :multdiv, :projals, :alspgrad)
+        for init in (:random, :nndsvd, :nndsvda, :nndsvdar)
+            ret = NMF.nnmf(X, k, alg=alg, init=init)
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,3 @@
+include("utils.jl")
+include("initialization.jl")
+include("alspgrad.jl")


### PR DESCRIPTION
This supports various element types (e.g., Float32). It also supports more general matrix-like objects (not necessarily even `AbstractArray`s, as long as they support operations like size, eltype, and multiplication).
