### PR TITLE
Added spa algorithm to NMF, compatibility for julia v0.6

### DIFF
--- a/src/NMF.jl
+++ b/src/NMF.jl
@@ -14,6 +14,7 @@ module NMF
     include("multupd.jl")
     include("projals.jl")
     include("alspgrad.jl")
+    include("spa.jl")
 
     include("interf.jl")
 

--- a/src/alspgrad.jl
+++ b/src/alspgrad.jl
@@ -47,7 +47,7 @@ immutable ALSGradUpdH_State{T}
     WtX::Matrix{T}    # W'X  (pre-computed)
     WtWD::Matrix{T}   # W'W * D
 
-    function ALSGradUpdH_State(X, W, H)
+    function ALSGradUpdH_State{T}(X, W, H) where T <: Real
         k, n = size(H)
         @compat new(Array{T,2}(k, n),
                     Array{T,2}(k, n),
@@ -65,7 +65,7 @@ function set_w!(s::ALSGradUpdH_State, X, W)
     At_mul_B!(s.WtX, W, X)
 end
 
-function alspgrad_updateh!{T}(X,
+function alspgrad_updateh!{T <: Real}(X,
                               W::VecOrMat{T},
                               H::VecOrMat{T};
                               maxiter::Int = 1000,
@@ -208,7 +208,7 @@ immutable ALSGradUpdW_State{T}
     XHt::Matrix{T}    # XH' (pre-computed)
     DHHt::Matrix{T}   # D * HH'
 
-    function ALSGradUpdW_State(X, W, H)
+    function ALSGradUpdW_State{T}(X, W, H) where T <: Real
         p, k = size(W)
         @compat new(Array{T,2}(p, k),
                     Array{T,2}(p, k),
@@ -368,11 +368,11 @@ type ALSPGrad{T}
     tolg::T     # tolerance of grad norm in sub-routine
     verbose::Bool     # whether to show procedural information (main)
 
-    function ALSPGrad(;maxiter::Integer=100,
+    function ALSPGrad{T}(;maxiter::Integer=100,
                        maxsubiter::Integer=200,
                        tol::Real=cbrt(eps(T)),
                        tolg::Real=eps(T)^(1/4),
-                       verbose::Bool=false)
+                       verbose::Bool=false) where T <: Real
         new(maxiter,
             maxsubiter,
             tol,
@@ -396,7 +396,7 @@ immutable ALSPGradUpd_State{T}
     uhstate::ALSGradUpdH_State
     uwstate::ALSGradUpdW_State
 
-    ALSPGradUpd_State(X, W, H) =
+    ALSPGradUpd_State{T}(X, W, H) where T <: Real =
         new(W * H,
             ALSGradUpdH_State(X, W, H),
             ALSGradUpdW_State(X, W, H))

--- a/src/common.jl
+++ b/src/common.jl
@@ -18,14 +18,14 @@ end
 
 # the result type
 
-immutable Result{T}
+immutable Result{T} <: Real
     W::Matrix{T}
     H::Matrix{T}
     niters::Int
     converged::Bool
     objvalue::T
 
-    function Result(W::Matrix{T}, H::Matrix{T}, niters::Int, converged::Bool, objv)
+    function Result{T}(W::Matrix{T}, H::Matrix{T}, niters::Int, converged::Bool, objv) where T <: Real
         if size(W, 2) != size(H, 1)
             throw(DimensionMismatch("Inner dimensions of W and H mismatch."))
         end
@@ -35,7 +35,7 @@ end
 
 # common algorithmic skeleton for iterative updating methods
 
-abstract NMFUpdater{T}
+abstract type NMFUpdater{T} end
 
 function nmf_skeleton!{T}(updater::NMFUpdater{T},
                           X, W::Matrix{T}, H::Matrix{T},

--- a/src/interf.jl
+++ b/src/interf.jl
@@ -22,6 +22,8 @@ function nnmf{T}(X::AbstractMatrix{T}, k::Integer;
         W, H = nndsvd(X, k; variant=:a, zeroh=!initH)
     elseif init == :nndsvdar
         W, H = nndsvd(X, k; variant=:ar, zeroh=!initH)
+    elseif init == :spa
+        W, H = spa(X, k)
     else
         throw(ArgumentError("Invalid value for init."))
     end
@@ -35,6 +37,8 @@ function nnmf{T}(X::AbstractMatrix{T}, k::Integer;
         alginst = MultUpdate{T}(obj=:mse, maxiter=maxiter, tol=tol, verbose=verbose)
     elseif alg == :multdiv
         alginst = MultUpdate{T}(obj=:div, maxiter=maxiter, tol=tol, verbose=verbose)
+    elseif alg == :spa
+        alginst = SPA{T}(obj=:mse)
     else
         throw(ArgumentError("Invalid algorithm."))
     end

--- a/src/multupd.jl
+++ b/src/multupd.jl
@@ -6,18 +6,18 @@
 #   Matrix Factorization. Advances in NIPS, 2001.
 #
 
-type MultUpdate{T}
+type MultUpdate{T} <: Real
     obj::Symbol         # objective :mse or :div
     maxiter::Int        # maximum number of iterations
     verbose::Bool       # whether to show procedural information
     tol::T              # change tolerance upon convergence
     lambda::T           # regularization coefficient
 
-    function MultUpdate(;obj::Symbol=:mse,
+    function MultUpdate{T}(;obj::Symbol=:mse,
                          maxiter::Integer=100,
                          verbose::Bool=false,
                          tol::Real=cbrt(eps(T)),
-                         lambda::Real=sqrt(eps(T)))
+                         lambda::Real=sqrt(eps(T))) where T <: Real
 
         obj == :mse || obj == :div || throw(ArgumentError("Invalid value for obj."))
         maxiter > 1 || throw(ArgumentError("maxiter must be greater than 1."))
@@ -43,14 +43,14 @@ immutable MultUpdMSE{T} <: NMFUpdater{T}
     lambda::T
 end
 
-immutable MultUpdMSE_State{T}
+immutable MultUpdMSE_State{T} 
     WH::Matrix{T}
     WtX::Matrix{T}
     WtWH::Matrix{T}
     XHt::Matrix{T}
     WHHt::Matrix{T}
 
-    function MultUpdMSE_State(X, W::Matrix{T}, H::Matrix{T})
+    function MultUpdMSE_State{T}(X, W::Matrix{T}, H::Matrix{T}) where T <: Real
         p, n, k = nmf_checksize(X, W, H)
         @compat new(W * H,
                     Array{T,2}(k, n),
@@ -107,7 +107,7 @@ immutable MultUpdDiv_State{T}
     WtQ::Matrix{T}    # W' * Q: size (k, n)
     QHt::Matrix{T}    # Q * H': size (p, k)
 
-    function MultUpdDiv_State(X, W::Matrix{T}, H::Matrix{T})
+    function MultUpdDiv_State{T}(X, W::Matrix{T}, H::Matrix{T}) where T <: Real 
         p, n, k = nmf_checksize(X, W, H)
         @compat new(W * H,
                     Array{T,2}(1, k),

--- a/src/projals.jl
+++ b/src/projals.jl
@@ -22,11 +22,11 @@ type ProjectedALS{T}
     lambda_w::T
     lambda_h::T
 
-    function ProjectedALS(;maxiter::Integer=100,
+    function ProjectedALS{T}(;maxiter::Integer=100,
                            verbose::Bool=false,
                            tol::Real=cbrt(eps(T)),
                            lambda_w::Real=cbrt(eps(T)),
-                           lambda_h::Real=cbrt(eps(T)))
+                           lambda_h::Real=cbrt(eps(T))) where T <: Real
 
         new(maxiter, verbose, tol, lambda_w, lambda_h)
     end
@@ -48,7 +48,7 @@ immutable ProjectedALSUpd_State{T}
     HHt::Matrix{T}
     XHt::Matrix{T}
 
-    function ProjectedALSUpd_State(X, W::Matrix{T}, H::Matrix{T})
+    function ProjectedALSUpd_State{T}(X, W::Matrix{T}, H::Matrix{T}) where T <:Real
         p, n, k = nmf_checksize(X, W, H)
         @compat new(W * H,
                     Array{T,2}(k, k),

--- a/src/spa.jl
+++ b/src/spa.jl
@@ -1,0 +1,57 @@
+using NonNegLeastSquares
+
+# Empty type, 
+type SPA{T}
+	obj::Symbol   # objective :mse or :div
+
+	function SPA{T}(;obj=:mse) where T <: Symbol
+		obj == :mse || obj == :div || error("Invalid value for obj.")
+        new(obj)
+    end
+end
+
+# initialization
+function spa(
+	X::Matrix,
+	k::Int;
+	nnls_alg = (:pivot,:cache)
+	)
+
+	# Normalize data so that columns of X sum to one
+	R = X ./ sum(X,1)
+
+	# W = R[:,ai], where ai are the "anchor indices"
+	# (ai forms the convex hull of columns in R)
+	ai = (Int64)[]
+
+	# Add columns of X that are furthest from span(W)
+	for j = 1:k
+		# Add column with the largest residual
+		push!(ai, indmax(sum(R.^2,1)))
+
+		# Project R onto the selected column
+		p = R[:,ai[j]]         # column we're projecting on
+		R -= p*(p'*R) ./(p'*p)  # new residual matrix
+	end
+
+	# Estimate W as the anchor columns of X
+	W = X[:,ai]
+
+	# Estimate H by non-negative least squares: minimize ||X - W*H||
+	H = nonneg_lsq(W,X,alg=nnls_alg[1],variant=nnls_alg[2])
+        #H = nonneg_lsq(W,X)
+
+	return W,H
+end
+
+# calculate statistics for result
+function solve!{T}(alg::SPA{T}, X, W, H)
+	if alg.obj == :mse
+		objv = sqL2dist(X, W*H)
+	elseif alg.obj == :div
+		objv = gkldiv(X, W*H)
+	else
+		error("Invalid value for obj.")
+	end
+	return Result{T}(W, H, 0, true, objv)
+end

--- a/test/alspgrad.jl
+++ b/test/alspgrad.jl
@@ -9,9 +9,10 @@ n = 8
 k = 3
 
 # Matrices
-for T in (Float64, Float32)
-    Wg = max(rand(T, p, k) .- 0.3, 0)
-    Hg = max(rand(T, k, n) .- 0.3, 0)
+
+T = Float64
+    Wg = max.(rand(T, p, k) .- 0.3, 0)
+    Hg = max.(rand(T, k, n) .- 0.3, 0)
     X = Wg * Hg
 
     # test update of H
@@ -19,14 +20,14 @@ for T in (Float64, Float32)
     H = rand(T, k, n)
     NMF.alspgrad_updateh!(X, Wg, H; maxiter=200)
     @test all(H .>= 0.0)
-    @test_approx_eq_eps H Hg eps(T)^(1/4)
+    @test H ≈ Hg atol = eps(T)^(1/4)
 
     # test update of W
 
     W = rand(T, p, k)
     NMF.alspgrad_updatew!(X, W, Hg; maxiter=200)
     @test all(W .>= 0.0)
-    @test_approx_eq_eps W Wg eps(T)^(1/4)
+    @test W ≈ Wg atol = eps(T)^(1/4)
 
     NMF.solve!(NMF.ALSPGrad{T}(), X, W, H)
-end
+

--- a/test/initialization.jl
+++ b/test/initialization.jl
@@ -21,7 +21,7 @@ W, H = NMF.randinit(X, 5; normalize=true)
 @test size(H) == (5, 12)
 @test all(W .>= 0.0)
 @test all(H .>= 0.0)
-@test_approx_eq vec(sum(W, 1)) ones(5)
+@test vec(sum(W, 1)) ≈ ones(5)
 
 ## nndsvd
 
@@ -30,7 +30,7 @@ W, H = NMF.nndsvd(X, 5)
 @test size(H) == (5, 12)
 @test all(W .>= 0.0)
 @test all(H .>= 0.0)
-@test_approx_eq_eps vec(sum(abs2(W),1)) ones(5) 1.0e-8
+@test vec(sum(abs2.(W),1)) ≈ ones(5) atol = 1.0e-8
 
 W2, H2 = NMF.nndsvd(X, 5; zeroh=true)
 @test size(W) == (8, 5)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,8 @@ using Base.Test
 
 tests = ["utils",
          "initialization",
-         "alspgrad"]
+         "alspgrad",
+	 "spa"]
 
 println("Running tests:")
 for t in tests

--- a/test/spa.jl
+++ b/test/spa.jl
@@ -1,0 +1,25 @@
+# some tests for spa
+
+# data
+
+srand(5678)
+
+p = 5
+n = 8
+k = 3
+
+# Matrices
+
+    T=Float64
+    Wg = max.(rand(T, p, k) .- 0.3, 0)
+    Hg = max.(rand(T, k, n) .- 0.3, 0)
+    X = Wg * Hg
+
+    #H = rand(T, k, n)
+
+    w,h=NMF.spa(X, k)
+    x=w*h
+    @test all(h+eps(T)^(1/4) .>= 0.0)
+    @test x ≈ X atol=eps(T) ^(1 / 4)
+
+

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -17,20 +17,20 @@ NMF.adddiag!(a, 2.5)
 
 a = rand(5)
 NMF.normalize1!(a)
-@test_approx_eq sum(a) 1.0
-
+#@test_approx_eq sum(a) 1.0
+@test  sum(a) ≈ 1.0
 ## normalize1_cols!
 
 a = rand(5, 6)
 NMF.normalize1_cols!(a)
-@test_approx_eq vec(sum(a,1)) ones(6)
-
+#@test_approx_eq vec(sum(a,1)) ones(6)
+@test vec(sum(a,1)) ≈ ones(6)
 ## projectnn!
 
 a0 = randn(5, 5)
 a = copy(a0)
 NMF.projectnn!(a)
-@test a == max(a0, 0.0)
+@test a == max.(a0, 0.0)
 
 ## posneg!
 
@@ -41,8 +41,8 @@ an = zeros(size(a))
 
 NMF.posneg!(a, ap, an)
 @test a == ac
-@test ap == max(a, 0.0)
-@test an == max(-a, 0.0)
+@test ap == max.(a, 0.0)
+@test an == max.(-a, 0.0)
 
 ## pdsolve!
 
@@ -50,7 +50,7 @@ A = make_pdmat(5)
 X = rand(5, 3)
 Y = A * X
 NMF.pdsolve!(A, Y)
-@test_approx_eq X Y
+@test X ≈ Y
 
 ## pdrsolve!
 
@@ -59,4 +59,4 @@ X = rand(4, 5)
 Y = X * B
 Xr = zeros(4, 5)
 NMF.pdrsolve!(Y, B, Xr)
-@test_approx_eq Xr X
+@test Xr ≈ X


### PR DESCRIPTION
A version I have used for the spa algorithm. Passes tests but may in some situations give questionable results. The questionable results come from my usage of NMF for mass spectra analysis where I remember that a year ago in some cases spa gives results essentially different from alspgrad. For these cases the spectra were about 30kbins and a few hundred of them. I never went into a detailed investigation of why.