### PR TITLE
Add greedy coordinate descent algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A Julia package for non-negative matrix factorization (NMF).
 - Lee & Seung's Multiplicative Update (for both MSE & Divergence objectives)
 - (Naive) Projected Alternate Least Squared
 - ALS Projected Gradient Methods
+- Coordinate Descent Methods
 - Random Initialization
 - NNDSVD Initialization
 - Sparse NMF
@@ -74,6 +75,7 @@ The function supports the following keyword arguments:
     - ``projals``:  (Naive) Projected Alternate Least Square
     - ``alspgrad``:  Alternate Least Square using Projected Gradient Descent
     - ``cd``: Coordinate Descent solver that uses Fast Hierarchical Alternating Least Squares (implemetation similar to scikit-learn)
+    - ``greedycd``: Greedy Coordinate Descent
 
 - ``maxiter``: Maximum number of iterations (default = ``100``).
 
@@ -196,6 +198,21 @@ The matrices ``W`` and ``H`` are updated in place.
                       shuffle::Bool=false)       # if true, randomize the order of coordinates in the CD solver
     ```
 
+- **Greedy Coordinate Descent**
+
+    Reference: Cho-Jui Hsieh and Inderjit S. Dhillon. Fast coordinate descent methods with variable selection for non-negative matrix factorization. In Proceedings of the 17th ACM SIGKDD International Conference on Knowledge Discovery and Data Mining, 1064–1072 (2011).
+    
+    This algorithm is a fast coordinate descent method with variable selection. 
+    Both ``W`` and ``H`` need to be initialized.
+
+    ```julia
+    GreedyCD(maxiter::Integer=100,  # maximum number of iterations (in main procedure)
+             verbose::Bool=false,   # whether to show procedural information
+             tol::Real=1.0e-6,      # tolerance of changes on W and H upon convergence
+             lambda_w::Real=0.0,    # L1 regularization coefficient for W
+             lambda_h::Real=0.0)    # L1 regularization coefficient for H
+    ```
+
 ## Examples
 
 Here are examples that demonstrate how to use this package to factorize a non-negative dense matrix.
@@ -241,7 +258,7 @@ NMF.solve!(NMF.ProjectedALS{Float64}(maxiter=50), X, W, H)
 import NMF
 
  # initialize
-W, H = NMF.nndsvdar(X, 5)
+W, H = NMF.nndsvd(X, 5, variant=:ar)
 
  # optimize 
 NMF.solve!(NMF.ALSPGrad{Float64}(maxiter=50, tolg=1.0e-6), X, W, H)
@@ -253,9 +270,21 @@ NMF.solve!(NMF.ALSPGrad{Float64}(maxiter=50, tolg=1.0e-6), X, W, H)
 import NMF
 
  # initialize
-W, H = NMF.nndsvdar(X, 5)
+W, H = NMF.nndsvd(X, 5, variant=:ar)
 
  # optimize 
 NMF.solve!(NMF.CoordinateDescent{Float64}(maxiter=50, α=0.5, l₁ratio=0.5), X, W, H)
+```
+
+#### Use Greedy Coordinate Descent
+
+```julia
+import NMF
+
+ # initialize
+W, H = NMF.nndsvd(X, 5, variant=:ar)
+
+ # optimize 
+NMF.solve!(NMF.GreedyCD{Float64}(maxiter=50), X, W, H)
 ```
 

--- a/examples/densenmf.jl
+++ b/examples/densenmf.jl
@@ -45,6 +45,8 @@ function print_help()
     println("    multdiv:   Multiplicative update (minimize divergence)")
     println("    projals:   Projected ALS")
     println("    alspgrad:  ALS Projected Gradient Descent")
+    println("    cd:        Coordinate Descent")
+    println("    greedycd:  Greedy Coordinate Descent")
     println()
 end
 

--- a/src/NMF.jl
+++ b/src/NMF.jl
@@ -14,6 +14,7 @@ module NMF
     include("projals.jl")
     include("alspgrad.jl")
     include("coorddesc.jl")
+    include("greedycd.jl")
 
     include("interf.jl")
 

--- a/src/alspgrad.jl
+++ b/src/alspgrad.jl
@@ -108,7 +108,7 @@ function _alspgrad_updateh!(X,                      # size (p, n)
         @printf("%5s    %12s    %12s    %12s    %8s    %12s\n",
             "Iter", "objv", "objv.change", "1st-ord", "alpha", "back-tracks")
         WH = W * H
-        objv = sqL2dist(X, WH)
+        objv = convert(T, 0.5) * sqL2dist(X, WH)
         @printf("%5d    %12.5e\n", 0, objv)
     end
 
@@ -189,7 +189,7 @@ function _alspgrad_updateh!(X,                      # size (p, n)
         if verbose
             mul!(WH, W, H)
             preobjv = objv
-            objv = sqL2dist(X, WH)
+            objv = convert(T, 0.5) * sqL2dist(X, WH)
             @printf("%5d    %12.5e    %12.5e    %12.5e    %8.4f    %12d\n",
                 t, objv, objv - preobjv, pgnrm, α, it)
         end
@@ -271,7 +271,7 @@ function _alspgrad_updatew!(X,                      # size (p, n)
         @printf("%5s    %12s    %12s    %12s    %8s    %12s\n",
             "Iter", "objv", "objv.change", "1st-ord", "alpha", "back-tracks")
         WH = W * H
-        objv = sqL2dist(X, WH)
+        objv = convert(T, 0.5) * sqL2dist(X, WH)
         @printf("%5d    %12.5e\n", 0, objv)
     end
 
@@ -352,7 +352,7 @@ function _alspgrad_updatew!(X,                      # size (p, n)
         if verbose
             mul!(WH, W, H)
             preobjv = objv
-            objv = sqL2dist(X, WH)
+            objv = convert(T, 0.5) * sqL2dist(X, WH)
             @printf("%5d    %12.5e    %12.5e    %12.5e    %8.4f    %12d\n",
                 t, objv, objv - preobjv, pgnrm, α, it)
         end
@@ -405,7 +405,7 @@ struct ALSPGradUpd_State{T}
 end
 
 prepare_state(::ALSPGradUpd{T}, X, W, H) where {T} = ALSPGradUpd_State{T}(X, W, H)
-evaluate_objv(u::ALSPGradUpd, s::ALSPGradUpd_State, X, W, H) = sqL2dist(X, s.WH)
+evaluate_objv(u::ALSPGradUpd{T}, s::ALSPGradUpd_State{T}, X, W, H) where T = convert(T, 0.5) * sqL2dist(X, s.WH)
 
 function update_wh!(upd::ALSPGradUpd, s::ALSPGradUpd_State, X, W, H)
     T = eltype(W)

--- a/src/common.jl
+++ b/src/common.jl
@@ -47,9 +47,10 @@ function nmf_skeleton!(updater::NMFUpdater{T},
     preW = Matrix{T}(undef, size(W))
     preH = Matrix{T}(undef, size(H))
     if verbose
+        start = time()
         objv = evaluate_objv(updater, state, X, W, H)
-        @printf("%-5s     %-13s    %-13s    %-13s\n", "Iter", "objv", "objv.change", "(W & H).change")
-        @printf("%5d    %13.6e\n", 0, objv)
+        @printf("%-5s    %-13s    %-13s    %-13s    %-13s\n", "Iter", "Elapsed time", "objv", "objv.change", "(W & H).change")
+        @printf("%5d    %13.6e    %13.6e\n", 0, 0.0, objv)
     end
 
     # main loop
@@ -71,10 +72,11 @@ function nmf_skeleton!(updater::NMFUpdater{T},
 
         # display info
         if verbose
+            elapsed = time() - start
             preobjv = objv
             objv = evaluate_objv(updater, state, X, W, H)
-            @printf("%5d    %13.6e    %13.6e    %13.6e\n",
-                t, objv, objv - preobjv, dev)
+            @printf("%5d    %13.6e    %13.6e    %13.6e    %13.6e\n",
+                t, elapsed, objv, objv - preobjv, dev)
         end
     end
 

--- a/src/coorddesc.jl
+++ b/src/coorddesc.jl
@@ -76,14 +76,18 @@ struct CoordinateDescentUpd{T} <: NMFUpdater{T}
 end
 
 mutable struct CoordinateDescentState{T}
+    WH::Matrix{T}
     violation::T
     violation_init::Union{Nothing, T}
+    CoordinateDescentState{T}(W, H, violation, violation_init) where {T} = new{T}(W * H, violation, violation_init)
 end
 
-prepare_state(::CoordinateDescentUpd{T}, X, W, H) where {T} =
- CoordinateDescentState(zero(T), nothing)
-evaluate_objv(::CoordinateDescentUpd{T}, s::CoordinateDescentState, X, W, H) where {T} = 
-    s.violation / (s.violation_init === nothing ? oneunit(T) : s.violation_init)
+prepare_state(::CoordinateDescentUpd{T}, X, W, H) where T = CoordinateDescentState{T}(W, H, zero(T), nothing)
+
+function evaluate_objv(::CoordinateDescentUpd{T}, s::CoordinateDescentState{T}, X, W, H) where T
+    mul!(s.WH, W, H)
+    convert(T, 0.5) * sqL2dist(X, s.WH)
+end
 
 "Updates W only"
 function _update_coord_descent!(X, W, H, l1_reg, l2_reg, shuffle)

--- a/src/greedycd.jl
+++ b/src/greedycd.jl
@@ -1,0 +1,167 @@
+# Greedy Coordinate Descent (GreedyCD) algorithm
+#
+# Author: Takehiro Sano 
+#
+# Reference: Cho-Jui Hsieh and Inderjit S. Dhillon. "Fast coordinate descent methods 
+#  with variable selection for non-negative matrix factorization." In Proceedings of 
+#  the 17th ACM SIGKDD International Conference on Knowledge Discovery and Data Mining, 
+#  pp. 1064–1072, 2011.
+
+mutable struct GreedyCD{T}
+    maxiter::Int           # maximum number of iterations (in main procedure)
+    verbose::Bool          # whether to show procedural information
+    tol::T                 # tolerance of changes on W and H upon convergence
+    lambda_w::T            # L1 regularization coefficient for W
+    lambda_h::T            # L1 regularization coefficient for H
+
+    function GreedyCD{T}(;maxiter::Integer=100,
+                          verbose::Bool=false,
+                          tol::Real=cbrt(eps(T)),
+                          lambda_w::Real=zero(T),
+                          lambda_h::Real=zero(T)) where T
+
+        maxiter > 1 || throw(ArgumentError("maxiter must be greater than 1."))
+        tol > 0 || throw(ArgumentError("tol must be positive."))
+        lambda_w >= 0 || throw(ArgumentError("lambda_w must be non-negative."))
+        lambda_h >= 0 || throw(ArgumentError("lambda_h must be non-negative."))
+        new{T}(maxiter, verbose, tol, lambda_w, lambda_h)
+    end
+end
+
+solve!(alg::GreedyCD{T}, X, W, H) where T = 
+    nmf_skeleton!(GreedyCDUpd{T}(alg.lambda_w, alg.lambda_h), X, W, H, alg.maxiter, alg.verbose, alg.tol)
+
+
+struct GreedyCDUpd{T} <: NMFUpdater{T}
+    lambda_w::T
+    lambda_h::T
+end
+
+mutable struct GreedyCDUpd_State{T}
+    WH::Matrix{T}
+    PWW::Matrix{T}
+    PHH::Matrix{T}
+    PXW::Matrix{T}
+    PXH::Matrix{T}
+    GW::Matrix{T}
+    GH::Matrix{T}
+    Wnew::Matrix{T}
+    Hnew::Matrix{T}
+    SW::Matrix{T}
+    SH::Matrix{T}
+    DW::Matrix{T}
+    DH::Matrix{T}
+    qW::Array{Int}
+    qH::Array{Int}
+    
+    function GreedyCDUpd_State{T}(X, W::Matrix{T}, H::Matrix{T}) where T
+        p, n, k = nmf_checksize(X, W, H)
+        new{T}(W * H, 
+               Matrix{T}(undef, k, k),
+               Matrix{T}(undef, k, k),
+               Matrix{T}(undef, p, k),
+               Matrix{T}(undef, n, k),
+               Matrix{T}(undef, p, k),
+               Matrix{T}(undef, n, k),
+               Matrix{T}(undef, p, k),
+               Matrix{T}(undef, n, k), 
+               Matrix{T}(undef, p, k),
+               Matrix{T}(undef, n, k),
+               Matrix{T}(undef, p, k),
+               Matrix{T}(undef, n, k), 
+               Array{Int}(undef, p),
+               Array{Int}(undef, n))
+    end
+end
+
+prepare_state(::GreedyCDUpd{T}, X, W, H) where {T} = GreedyCDUpd_State{T}(X, W, H)
+
+function evaluate_objv(u::GreedyCDUpd{T}, s::GreedyCDUpd_State{T}, X, W, H) where T
+    mul!(s.WH, W, H)
+    r = convert(T, 0.5) * sqL2dist(X, s.WH)
+    if u.lambda_w > 0
+        r += u.lambda_w * norm(W, 1)
+    end
+    if u.lambda_h > 0
+        r += u.lambda_h * norm(H, 1)
+    end
+    return r
+end
+
+function _update_GreedyCD!(upd::GreedyCDUpd{T}, s::GreedyCDUpd_State{T}, X, 
+                           W::AbstractArray{T}, Ht::AbstractArray{T}, W_flag::Bool) where T
+    if W_flag
+        lambda = upd.lambda_w
+        Wnew = s.Wnew
+        P = s.PWW
+        Z = s.PXW
+        G = s.GW
+        S = s.SW
+        D = s.DW
+        q = s.qW
+    else
+        lambda = upd.lambda_h
+        Wnew = s.Hnew
+        P = s.PHH
+        Z = s.PXH
+        G = s.GH
+        S = s.SH
+        D = s.DH
+        q = s.qH
+    end
+    n_samples, n_components = size(W)
+
+    mul!(P, transpose(Ht), Ht)
+    mul!(Z, X, Ht) 
+    mul!(G, W, P)
+    G = G .- Z .+ lambda
+
+    for r in 1:n_components
+        for i in 1:n_samples
+            S[i, r] = max(zero(T), W[i, r] - G[i, r] / (eps(T) + P[r, r])) - W[i, r]
+            D[i, r] = - G[i, r] * S[i, r] - convert(T, 0.5) * P[r, r] * S[i, r]^2
+        end
+    end
+
+    p_init = convert(T, -1.0)
+    for i in 1:n_samples
+        qi = argmax(D[i, :])
+        q[i] = qi
+        p_init = max(p_init, D[i, qi])
+    end
+
+    fill!(Wnew, zero(T))
+    nu = convert(T, 0.001)
+
+    for i in 1:n_samples
+        for _ in 1:n_components^2
+            qi = q[i]
+            if D[i, qi] < nu * p_init
+                break
+            end
+
+            s = S[i, qi]
+            Wnew[i, qi] += s
+            G[i, :] = G[i, :] .+ (s .* P[qi, :])
+
+            for r in 1:n_components
+                S[i, r] = max(zero(T), W[i, r] - G[i, r] / (eps(T) + P[r, r])) - W[i, r]
+                D[i, r] = - G[i, r] * S[i, r] - convert(T, 0.5) * P[r, r] * S[i, r]^2
+            end
+
+            q[i] = argmax(D[i, :])
+        end
+    end
+    copyto!(W, W + Wnew)
+    projectnn!(W) # countermeasure on rounding error
+end
+
+function update_wh!(upd::GreedyCDUpd{T}, s::GreedyCDUpd_State{T}, X, W::Matrix{T}, H::Matrix{T}) where T
+    # update W
+    Ht = transpose(H)
+    _update_GreedyCD!(upd, s, X, W, Ht, true)
+
+    # update H
+    Xt = transpose(X)
+    _update_GreedyCD!(upd, s, Xt, Ht, W, false)
+end

--- a/src/interf.jl
+++ b/src/interf.jl
@@ -2,7 +2,7 @@
 
 function nnmf(X::AbstractMatrix{T}, k::Integer;
               init::Symbol=:nndsvdar,
-              alg::Symbol=:alspgrad,
+              alg::Symbol=:greedycd,
               maxiter::Integer=100,
               tol::Real=cbrt(eps(T)/100),
               verbose::Bool=false) where T
@@ -37,6 +37,8 @@ function nnmf(X::AbstractMatrix{T}, k::Integer;
         alginst = MultUpdate{T}(obj=:div, maxiter=maxiter, tol=tol, verbose=verbose)
     elseif alg == :cd
         alginst = CoordinateDescent{T}(maxiter=maxiter, tol=tol, verbose=verbose)
+    elseif alg == :greedycd
+        alginst = GreedyCD{T}(maxiter=maxiter, tol=tol, verbose=verbose)
     else
         throw(ArgumentError("Invalid algorithm."))
     end

--- a/src/multupd.jl
+++ b/src/multupd.jl
@@ -75,7 +75,7 @@ struct MultUpdMSE_State{T}
 end
 
 prepare_state(::MultUpdMSE{T}, X, W, H) where {T} = MultUpdMSE_State{T}(X, W, H)
-evaluate_objv(::MultUpdMSE, s::MultUpdMSE_State, X, W, H) = sqL2dist(X, s.WH)
+evaluate_objv(::MultUpdMSE{T}, s::MultUpdMSE_State{T}, X, W, H) where T = convert(T, 0.5) * sqL2dist(X, s.WH)
 
 function update_wh!(upd::MultUpdMSE{T}, s::MultUpdMSE_State{T}, X, W::Matrix{T}, H::Matrix{T}) where T
 

--- a/test/greedycd.jl
+++ b/test/greedycd.jl
@@ -1,0 +1,30 @@
+# some tests for GreedyCD
+
+using NMF
+using Test
+
+p = 5
+n = 8
+k = 3
+
+Random.seed!(1234)
+
+for T in (Float64, Float32)
+    for lambda_w in (0.0, 1e-4)
+        for lambda_h in (0.0, 1e-4)
+            Wg = max.(rand(T, p, k) .- T(0.5), zero(T))
+            Hg = max.(rand(T, k, n) .- T(0.5), zero(T))
+            X = Wg * Hg
+            W = Wg .+ rand(T, p, k) * T(0.1)
+
+            NMF.solve!(NMF.GreedyCD{T}(maxiter=1000, tol=1e-9, lambda_w=lambda_w, lambda_h=lambda_h), X, W, Hg)
+
+            @test all(W .>= 0.0)
+            @test all(Hg .>= 0.0)
+            @test !any(isnan.(W)) 
+            @test !any(isnan.(Hg)) 
+            @test X ≈ W * Hg atol = 1e-3
+        end
+    end
+end
+

--- a/test/interf.jl
+++ b/test/interf.jl
@@ -9,7 +9,7 @@ for T in (Float64, Float32)
     Hg = max.(rand(T, k, n) .- 0.3, 0)
     X = Wg * Hg
 
-    for alg in (:multmse, :multdiv, :projals, :alspgrad, :cd)
+    for alg in (:multmse, :multdiv, :projals, :alspgrad, :cd, :greedycd)
         for init in (:random, :nndsvd, :nndsvda, :nndsvdar)
             ret = NMF.nnmf(X, k, alg=alg, init=init)
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ tests = ["utils",
          "multupd", 
          "alspgrad",
          "coorddesc",
+         "greedycd",
          "interf"]
 
 println("Running tests:")


### PR DESCRIPTION
I implemented a greedy coordinate descent algorithm [1] for MSE-based NMF and confirmed that the algorithm works fast and stable for both dense and sparse matrices. The benchmark is [here][bench]. Furthermore, I unified the definition of the objective function for each algorithm. 

[1] Cho-Jui Hsieh and Inderjit S. Dhillon. "Fast coordinate descent methods with variable selection for non-negative matrix factorization." In Proceedings of the 17th ACM SIGKDD International Conference on Knowledge Discovery and Data Mining, pp. 1064–1072, 2011.

[bench]: https://gist.github.com/tsano430/68de73c79543971a649177bd8322d53a