### PR TITLE
Fix#15: Avoidance of zero division

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,11 +143,12 @@ The matrices ``W`` and ``H`` are updated in place.
     This algorithm has two different kind of objectives: minimizing mean-squared-error (``:mse``) and minimizing divergence (``:div``). Both ``W`` and ``H`` need to be initialized.
 
     ```julia
-    MultUpdate(obj=:mse,        # objective, either :mse or :div
-               maxiter=100,     # maximum number of iterations
-               verbose=false,   # whether to show procedural information
-               tol=1.0e-6,      # tolerance of changes on W and H upon convergence
-               lambda=1.0e-9)   # regularization coefficients (added to the denominator)
+    MultUpdate(obj::Symbol=:mse,        # objective, either :mse or :div
+               maxiter::Integer=100,    # maximum number of iterations
+               verbose::Bool=false,     # whether to show procedural information
+               tol::Real=1.0e-6,        # tolerance of changes on W and H upon convergence
+               lambda_w::Real=0.0,      # L1 regularization coefficient for W
+               lambda_h::Real=0.0)      # L1 regularization coefficient for H
     ```
 
     **Note:** the values above are default values for the keyword arguments. One can override part (or all) of them.

--- a/src/multupd.jl
+++ b/src/multupd.jl
@@ -7,25 +7,31 @@
 #
 
 mutable struct MultUpdate{T}
-    obj::Symbol     # objective :mse or :div
-    maxiter::Int    # maximum number of iterations
-    verbose::Bool   # whether to show procedural information
-    tol::T          # change tolerance upon convergence
-    lambda_w::T     # L1 regularization coefficient for W
-    lambda_h::T     # L1 regularization coefficient for H
+    obj::Symbol                 # objective :mse or :div
+    maxiter::Int                # maximum number of iterations
+    verbose::Bool               # whether to show procedural information
+    tol::T                      # change tolerance upon convergence
+    lambda_w::T                 # L1 regularization coefficient for W
+    lambda_h::T                 # L1 regularization coefficient for H
 
     function MultUpdate{T}(;obj::Symbol=:mse,
                             maxiter::Integer=100,
                             verbose::Bool=false,
                             tol::Real=cbrt(eps(T)),
                             lambda_w::Real=zero(T),
-                            lambda_h::Real=zero(T)) where T
+                            lambda_h::Real=zero(T),
+                            lambda::Union{Real, Nothing}=nothing) where T
 
         obj == :mse || obj == :div || throw(ArgumentError("Invalid value for obj."))
         maxiter > 1 || throw(ArgumentError("maxiter must be greater than 1."))
         tol > 0 || throw(ArgumentError("tol must be positive."))
         lambda_w >= 0 || throw(ArgumentError("lambda_w must be non-negative."))
         lambda_h >= 0 || throw(ArgumentError("lambda_h must be non-negative."))
+        if !isnothing(lambda) && lambda >= 0
+            @warn "lambda is deprecated, use lambda_w and lambda_h instead."
+            lambda_w = iszero(lambda_w) ? lambda : lambda_w
+            lambda_h = iszero(lambda_h) ? lambda : lambda_h
+        end
         if obj == :div
             lambda_w = max(lambda_w, sqrt(eps(T)))
             lambda_h = max(lambda_h, sqrt(eps(T)))

--- a/src/multupd.jl
+++ b/src/multupd.jl
@@ -26,6 +26,10 @@ mutable struct MultUpdate{T}
         tol > 0 || throw(ArgumentError("tol must be positive."))
         lambda_w >= 0 || throw(ArgumentError("lambda_w must be non-negative."))
         lambda_h >= 0 || throw(ArgumentError("lambda_h must be non-negative."))
+        if obj == :div
+            lambda_w = max(lambda_w, sqrt(eps(T)))
+            lambda_h = max(lambda_h, sqrt(eps(T)))
+        end
         new{T}(obj, maxiter, verbose, tol, lambda_w, lambda_h)
     end
 end
@@ -158,11 +162,7 @@ function update_wh!(upd::MultUpdDiv{T}, s::MultUpdDiv_State{T}, X, W::Matrix{T},
     mul!(WtQ, transpose(W), Q)
     sum!(fill!(sW, 0), W)
     @inbounds for j = 1:n, i = 1:k
-        if lambda_h > zero(T)
-            H[i,j] *= (WtQ[i,j] / (sW[i] + lambda_h))
-        else
-            H[i,j] *= (WtQ[i,j] / (sW[i] + delta))
-        end
+        H[i,j] *= (WtQ[i,j] / (sW[i] + lambda_h))
     end
     mul!(WH, W, H)
 
@@ -173,11 +173,7 @@ function update_wh!(upd::MultUpdDiv{T}, s::MultUpdDiv_State{T}, X, W::Matrix{T},
     mul!(QHt, Q, transpose(H))
     sum!(fill!(sH, 0), H)
     @inbounds for j = 1:k, i = 1:p
-        if lambda_w > zero(T)
-            W[i,j] *= (QHt[i,j] / (sH[j] + lambda_w))
-        else
-            W[i,j] *= (QHt[i,j] / (sH[j] + delta))
-        end
+        W[i,j] *= (QHt[i,j] / (sH[j] + lambda_w))
     end
     mul!(WH, W, H)
 end

--- a/src/multupd.jl
+++ b/src/multupd.jl
@@ -27,7 +27,7 @@ mutable struct MultUpdate{T}
         tol > 0 || throw(ArgumentError("tol must be positive."))
         lambda_w >= 0 || throw(ArgumentError("lambda_w must be non-negative."))
         lambda_h >= 0 || throw(ArgumentError("lambda_h must be non-negative."))
-        if !isnothing(lambda) && lambda >= 0
+        if lambda !== nothing && lambda >= 0
             @warn "lambda is deprecated, use lambda_w and lambda_h instead."
             lambda_w = iszero(lambda_w) ? lambda : lambda_w
             lambda_h = iszero(lambda_h) ? lambda : lambda_h

--- a/src/multupd.jl
+++ b/src/multupd.jl
@@ -148,7 +148,7 @@ function update_wh!(upd::MultUpdDiv{T}, s::MultUpdDiv_State{T}, X, W::Matrix{T},
     mul!(WtQ, transpose(W), Q)
     sum!(fill!(sW, 0), W)
     @inbounds for j = 1:n, i = 1:k
-        H[i,j] *= (WtQ[i,j] / sW[i])
+        H[i,j] *= (WtQ[i,j] / (sW[i] + lambda))
     end
     mul!(WH, W, H)
 
@@ -159,7 +159,7 @@ function update_wh!(upd::MultUpdDiv{T}, s::MultUpdDiv_State{T}, X, W::Matrix{T},
     mul!(QHt, Q, transpose(H))
     sum!(fill!(sH, 0), H)
     @inbounds for j = 1:k, i = 1:p
-        W[i,j] *= (QHt[i,j] / sH[j])
+        W[i,j] *= (QHt[i,j] / (sH[j] + lambda))
     end
     mul!(WH, W, H)
 end

--- a/test/multupd.jl
+++ b/test/multupd.jl
@@ -1,0 +1,29 @@
+using NMF
+using Test
+
+p = 5
+n = 8
+k = 3
+
+Random.seed!(5678)
+
+for T in (Float64, Float32)
+    for alg in (:mse, :div)
+        for lambda_w in (0.0, 1e-4)
+            for lambda_h in (0.0, 1e-4)
+                Wg = max.(rand(T, p, k) .- T(0.5), zero(T))
+                Hg = max.(rand(T, k, n) .- T(0.5), zero(T))
+                X = Wg * Hg
+                W = Wg .+ rand(T, p, k)*T(0.1)
+
+                NMF.solve!(NMF.MultUpdate{T}(obj=alg, maxiter=5000, tol=1e-9, lambda_w=lambda_w, lambda_h=lambda_h), X, W, Hg)
+                
+                @test all(W .>= 0.0)
+                @test all(Hg .>= 0.0)
+                @test !any(isnan.(W)) 
+                @test !any(isnan.(Hg)) 
+                @test X ≈ W * Hg atol=1e-2
+            end
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ using LinearAlgebra
 
 tests = ["utils",
          "initialization",
+         "multupd", 
          "alspgrad",
          "coorddesc",
          "interf"]


### PR DESCRIPTION
I fixed #15 by adding a small positive constant `lambda` to the denominator of the update rules. 