### PR TITLE
Fix #29: Reimplement alternate least square using projected gradient descent

### DIFF
--- a/examples/densenmf.jl
+++ b/examples/densenmf.jl
@@ -1,16 +1,19 @@
 # NMF for dense matrices
 
 using NMF
+using Printf
+using Random
 
 function run(algname)
 
     # prepare data
+    Random.seed!(5678)
     p = 8
     k = 5
     n = 100
 
-    Wg = abs(randn(p, k))
-    Hg = abs(randn(k, n))
+    Wg = abs.(randn(p, k))
+    Hg = abs.(randn(k, n))
     X = Wg * Hg + 0.1 * randn(p, n)
 
     # run NNMF
@@ -19,7 +22,7 @@ function run(algname)
 
     r = nnmf(X, k; 
              init=:nndsvdar,
-             alg=symbol(algname), 
+             alg=Symbol(algname), 
              maxiter=30, 
              verbose=true)
 

--- a/test/alspgrad.jl
+++ b/test/alspgrad.jl
@@ -17,14 +17,14 @@ for T in (Float64, Float32)
     # test update of H
 
     H = rand(T, k, n)
-    NMF.alspgrad_updateh!(X, Wg, H; maxiter=200)
+    NMF.alspgrad_updateh!(X, Wg, H; maxiter=1000, tolg=eps(T))
     @test all(H .>= 0.0)
     @test H ≈ Hg atol=eps(T)^(1/4)
 
     # test update of W
 
     W = rand(T, p, k)
-    NMF.alspgrad_updatew!(X, W, Hg; maxiter=200)
+    NMF.alspgrad_updatew!(X, W, Hg; maxiter=1000, tolg=eps(T))
     @test all(W .>= 0.0)
     @test W ≈ Wg atol=eps(T)^(1/4)
 


### PR DESCRIPTION
 I fixed #29 by reimplementing `alspgrad.jl` as in the following original paper:

Chih-Jen Lin, Projected Gradient Methods for Non-negative Matrix Factorization, Neural Computing, 19 (2007). 

[Here](https://gist.github.com/tsano430/0ebcb274f54eb2e6432e405bf6b8abc0#file-alspgrad-m) is the MATLAB code in the original paper. In addition, I fixed the parameters `maxiter` and `tolg` in `test/alspgrad.jl` because they prevented `alspgrad.jl` from obtaining a high-precision solution. 