### PR TITLE
Fix replicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The function supports the following keyword arguments:
     - ``nndsvd``:  standard version of NNDSVD
     - ``nndsvda``:  NNDSVDa variant
     - ``nndsvdar``:  NNDSVDar variant  
+    - ``custom``: use custom matrices ``W0`` and ``H0`` 
                 
 - ``alg``:  A symbol that indicates the factorization algorithm (default = ``:alspgrad``).
 
@@ -82,7 +83,10 @@ The function supports the following keyword arguments:
 - ``tol``: tolerance of changes upon convergence (default = ``1.0e-6``).
 
 - ``replicates``: Number of times to perform factorization (default = ``1``).
-  Further replications are not performed once the algorithm has converged.
+
+- ``W0``: Option for custom initialization (default = ``nothing``)
+
+- ``H0``: Option for custom initialization (default = ``nothing``)
 
 - ``verbose``: whether to show procedural information (default = ``false``).
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ The function supports the following keyword arguments:
 - ``W0``: Option for custom initialization (default = ``nothing``)
 
 - ``H0``: Option for custom initialization (default = ``nothing``)
+   
+  **Note:** ``W0`` and ``H0`` may be overwritten. If one needs to avoid it, please pass in copies themselves.
 
 - ``verbose``: whether to show procedural information (default = ``false``).
 

--- a/src/interf.jl
+++ b/src/interf.jl
@@ -42,7 +42,7 @@ function nnmf(X::AbstractMatrix{T}, k::Integer;
     elseif init == :nndsvdar
         W, H = nndsvd(X, k; variant=:ar, zeroh=!initH)
     elseif init == :custom
-        W, H = copy(W0), copy(H0)
+        W, H = W0, H0
     else
         throw(ArgumentError("Invalid value for init."))
     end

--- a/src/interf.jl
+++ b/src/interf.jl
@@ -42,7 +42,7 @@ function nnmf(X::AbstractMatrix{T}, k::Integer;
     elseif init == :nndsvdar
         W, H = nndsvd(X, k; variant=:ar, zeroh=!initH)
     elseif init == :custom
-        W, H = W0, H0
+        W, H = copy(W0), copy(H0)
     else
         throw(ArgumentError("Invalid value for init."))
     end

--- a/test/interf.jl
+++ b/test/interf.jl
@@ -16,7 +16,6 @@ for T in (Float64, Float32)
     end
 
     # replicates test
-    ret3 = NMF.nnmf(X, k, replicates=3)
-    ret5 = NMF.nnmf(X, k, replicates=5)
-    @test ret3.objvalue > ret5.objvalue
+    rep = NMF.nnmf(X, k, replicates=10, maxiter=10, alg=:multmse)
+    ret = NMF.nnmf(X, k, W0=rep.W, H0=rep.H, init=:custom)
 end


### PR DESCRIPTION
This PR fixes #48. 

`replicates` is number of times to perform the factorization. Any algorithm chooses new random initial values for W and H at each replication, except at the first replication specified by `init`. Among the results of all replications, `nnmf` returns W and H that have the smallest objective function value. For example, the usage of `replicates` is as follows: 

```julia
rep = NMF.nnmf(X, k, replicates=10, maxiter=5, alg=:multmse)
ret = NMF.nnmf(X, k, W0=rep.W, H0=rep.H, init=:custom)
```