### PR TITLE
Add an option for specifying whether to update H

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The function supports the following keyword arguments:
     - ``spa``: Successive Projection Algorithm
     - ``custom``: use custom matrices ``W0`` and ``H0`` 
                 
-- ``alg``:  A symbol that indicates the factorization algorithm (default = ``:alspgrad``).
+- ``alg``:  A symbol that indicates the factorization algorithm (default = ``:greedycd``).
 
     This argument accepts the following values:
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ The function supports the following keyword arguments:
    
   **Note:** ``W0`` and ``H0`` may be overwritten. If one needs to avoid it, please pass in copies themselves.
 
+- ``update_H``: Option for specifying whether to update H (default = ``true``).
+
 - ``verbose``: whether to show procedural information (default = ``false``).
 
 
@@ -174,6 +176,7 @@ The matrices ``W`` and ``H`` are updated in place.
                maxiter::Integer=100,    # maximum number of iterations
                verbose::Bool=false,     # whether to show procedural information
                tol::Real=1.0e-6,        # tolerance of changes on W and H upon convergence
+               update_H::Bool=true,     # whether to update H
                lambda_w::Real=0.0,      # L1 regularization coefficient for W
                lambda_h::Real=0.0)      # L1 regularization coefficient for H
     ```
@@ -189,6 +192,7 @@ The matrices ``W`` and ``H`` are updated in place.
     ProjectedALS(maxiter::Integer=100,    # maximum number of iterations
                  verbose::Bool=false,     # whether to show procedural information
                  tol::Real=1.0e-6,        # tolerance of changes on W and H upon convergence
+                 update_H::Bool=true,     # whether to update H
                  lambda_w::Real=1.0e-6,   # L2 regularization coefficient for W
                  lambda_h::Real=1.0e-6)   # L2 regularization coefficient for H
     ```
@@ -204,6 +208,7 @@ The matrices ``W`` and ``H`` are updated in place.
              maxsubiter::Integer=200,   # maximum number of iterations in solving each sub-problem
              tol::Real=1.0e-6,          # tolerance of changes on W and H upon convergence
              tolg::Real=1.0e-4,         # tolerable gradient norm in sub-problem (first-order optimality)
+             update_H::Bool=true,       # whether to update H
              verbose::Bool=false)       # whether to show procedural information
     ```
 
@@ -217,6 +222,7 @@ The matrices ``W`` and ``H`` are updated in place.
     CoordinateDescent(maxiter::Integer=100,      # maximum number of iterations (in main procedure)
                       verbose::Bool=false,       # whether to show procedural information
                       tol::Real=1.0e-6,          # tolerance of changes on W and H upon convergence
+                      update_H::Bool=true,       # whether to update H
                       α::Real=0.0,               # constant that multiplies the regularization terms
                       regularization=:both,      # select whether the regularization affects the components (H), the transformation (W), both or none of them (:components, :transformation, :both, :none)
                       l₁ratio::Real=0.0,         # l1 / l2 regularization mixing parameter (in [0; 1])
@@ -234,6 +240,7 @@ The matrices ``W`` and ``H`` are updated in place.
     GreedyCD(maxiter::Integer=100,  # maximum number of iterations (in main procedure)
              verbose::Bool=false,   # whether to show procedural information
              tol::Real=1.0e-6,      # tolerance of changes on W and H upon convergence
+             update_H::Bool=true,   # whether to update H
              lambda_w::Real=0.0,    # L1 regularization coefficient for W
              lambda_h::Real=0.0)    # L1 regularization coefficient for H
     ```

--- a/test/coorddesc.jl
+++ b/test/coorddesc.jl
@@ -1,5 +1,4 @@
-using NMF
-using Test
+# some tests for CoordinateDescent
 
 p = 5
 n = 8

--- a/test/greedycd.jl
+++ b/test/greedycd.jl
@@ -1,8 +1,5 @@
 # some tests for GreedyCD
 
-using NMF
-using Test
-
 p = 5
 n = 8
 k = 3

--- a/test/interf.jl
+++ b/test/interf.jl
@@ -21,4 +21,13 @@ for T in (Float64, Float32)
 
     # spa test 
     ret = NMF.nnmf(X, k, alg=:spa, init=:spa)
+
+    # update_H test
+    W = max.(rand(T, p, k) .- 0.3, 0)
+    H = max.(rand(T, k, n) .- 0.3, 0)
+    for alg in (:multmse, :multdiv, :projals, :alspgrad, :cd, :greedycd)
+        ret = NMF.nnmf(X, k, alg=alg, init=:custom, W0=copy(W), H0=copy(H), update_H=false)
+        @test all(H .== ret.H)
+        @test any(W .!= ret.W)
+    end
 end

--- a/test/multupd.jl
+++ b/test/multupd.jl
@@ -1,5 +1,4 @@
-using NMF
-using Test
+# some tests for MultUpdate
 
 p = 5
 n = 8


### PR DESCRIPTION
This PR fixes #44 .

```julia
X1 = rand(50, 100) # reference data set
X2 = rand(50, 100) # target data set
k = 3

# use a reference data set to produce the "components"
ret1 = nnmf(X1, k)

# fit a target data set to those components
W0 = ret1.W # or any initialization: for example, W0 = rand(size(X2)[1], k)
ret2 = nnmf(X2, k, init=:custom, W0=W0, H0=ret1.H, update_H=false)
```
