### PR TITLE
Improve coordinate descent algorithm

### DIFF
--- a/test/coorddesc.jl
+++ b/test/coorddesc.jl
@@ -9,8 +9,14 @@ for T in (Float64, Float32)
     Hg = max.(rand(T, k, n) .- T(0.5), zero(T))
     X = Wg * Hg
     W = Wg .+ rand(T, p, k)*T(0.1)
-
     NMF.solve!(NMF.CoordinateDescent{T}(α=0.0, maxiter=1000, tol=1e-9), X, W, Hg)
-
     @test X ≈ W * Hg atol=1e-4
+
+    # Regularization
+    Wg = max.(rand(T, p, k) .- T(0.5), zero(T))
+    Hg = max.(rand(T, k, n) .- T(0.5), zero(T))
+    X = Wg * Hg
+    W = Wg .+ rand(T, p, k)*T(0.1)
+    NMF.solve!(NMF.CoordinateDescent{T}(α=1e-4, l₁ratio=0.5, shuffle=true, maxiter=1000, tol=1e-9), X, W, Hg)
+    @test X ≈ W * Hg atol=1e-2
 end


### PR DESCRIPTION
From Issue #43 , I found that `src/coorddesc.jl` had a fatal problem on memory allocation. This PR improves the problem. 

```julia
julia> Random.seed!(1234);

julia> Y = rand(1000, 1000);

julia> @btime nnmf($Y, 10, init=:nndsvd, alg=:cd, maxiter=100);
  358.167 ms (33 allocations: 54.06 MiB)
```