### PR TITLE
Add precompilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          - '1.6'
           - '1' # automatically expands to the latest stable 1.x release of Julia
           - nightly
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NMF"
 uuid = "6ef6ca0d-6ad7-5ff6-b225-e928bfa0a386"
 license = "MIT"
-version = "0.5.3"
+version = "1.0.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -9,14 +9,16 @@ NonNegLeastSquares = "b7351bd1-99d9-5c5d-8786-f205a815c4d7"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RandomizedLinAlg = "0448d7d9-159c-5637-8537-fd72090fea46"
+SnoopPrecompile = "66db9d55-30c0-4569-8b51-7e840670fc0c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 NonNegLeastSquares = "0.2.0, 0.3.0, 0.4.0"
 RandomizedLinAlg = "0.1.0"
+SnoopPrecompile = "1"
 StatsBase = "0.25, 0.26, 0.27, 0.28, 0.29, 0.30, 0.31, 0.32, 0.33"
-julia = "0.7, 1"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/NMF.jl
+++ b/src/NMF.jl
@@ -22,4 +22,18 @@ module NMF
 
     include("interf.jl")
 
+    using SnoopPrecompile
+
+    let
+        @precompile_setup begin
+            X = rand(8, 6)
+            @precompile_all_calls begin
+                for alg in (:multmse, :multdiv, :projals, :alspgrad, :cd, :greedycd)
+                    for init in (:random, :nndsvd, :nndsvda, :nndsvdar, :spa)
+                        nnmf(X, 4, alg=alg, init=init)
+                    end
+                end
+            end
+        end
+    end
 end # module


### PR DESCRIPTION
Especially on (the upcoming) Julia 1.9, this greatly reduces TTFX,
from >5s to ~10ms on my machine.

Because SnoopPrecompile does not support Julia 0.7, this PR requires
that we abandon support for very old Julia versions, and that in turn
requires a minor version bump (policy of the General registry).
Since this package isn't changing quickly, I recommend taking the leap
to 1.0.

See #69 for the test failure. After merging that PR, you can close and reopen this to re-run the tests.