### PR TITLE
Switch to testsets

### DIFF
--- a/test/alspgrad.jl
+++ b/test/alspgrad.jl
@@ -1,32 +1,32 @@
 # some tests for ALSPGrad
 
-# data
+@testset "alspgrad" begin
+    # data
+    p = 5
+    n = 8
+    k = 3
 
-Random.seed!(5678)
+    # Matrices
+    for T in (Float64, Float32)
+        Wg = max.(rand(T, p, k) .- T(0.3), zero(T))
+        Hg = max.(rand(T, k, n) .- T(0.3), zero(T))
+        X = Wg * Hg
 
-p = 5
-n = 8
-k = 3
+        # test update of H
 
-# Matrices
-for T in (Float64, Float32)
-    Wg = max.(rand(T, p, k) .- T(0.3), zero(T))
-    Hg = max.(rand(T, k, n) .- T(0.3), zero(T))
-    X = Wg * Hg
+        H = rand(T, k, n)
+        NMF.alspgrad_updateh!(X, Wg, H; maxiter=1000, tolg=eps(T))
+        @test all(H .>= zero(T))
+        @test H ≈ Hg atol=eps(T)^(1/4)
 
-    # test update of H
+        # test update of W
 
-    H = rand(T, k, n)
-    NMF.alspgrad_updateh!(X, Wg, H; maxiter=1000, tolg=eps(T))
-    @test all(H .>= zero(T))
-    @test H ≈ Hg atol=eps(T)^(1/4)
+        W = rand(T, p, k)
+        NMF.alspgrad_updatew!(X, W, Hg; maxiter=1000, tolg=eps(T))
+        @test all(W .>= zero(T))
+        @test W ≈ Wg atol=eps(T)^(1/4)
 
-    # test update of W
+        NMF.solve!(NMF.ALSPGrad{T}(), X, W, H)
+    end
 
-    W = rand(T, p, k)
-    NMF.alspgrad_updatew!(X, W, Hg; maxiter=1000, tolg=eps(T))
-    @test all(W .>= zero(T))
-    @test W ≈ Wg atol=eps(T)^(1/4)
-
-    NMF.solve!(NMF.ALSPGrad{T}(), X, W, H)
 end

--- a/test/coorddesc.jl
+++ b/test/coorddesc.jl
@@ -1,22 +1,24 @@
 # some tests for CoordinateDescent
 
-p = 5
-n = 8
-k = 3
+@testset "coorddesc" begin
+    p = 5
+    n = 8
+    k = 3
 
-for T in (Float64, Float32)
-    Wg = max.(rand(T, p, k) .- T(0.5), zero(T))
-    Hg = max.(rand(T, k, n) .- T(0.5), zero(T))
-    X = Wg * Hg
-    W = Wg .+ rand(T, p, k)*T(0.1)
-    NMF.solve!(NMF.CoordinateDescent{T}(α=0.0, maxiter=1000, tol=1e-9), X, W, Hg)
-    @test X ≈ W * Hg atol=1e-4
+    for T in (Float64, Float32)
+        Wg = max.(rand(T, p, k) .- T(0.5), zero(T))
+        Hg = max.(rand(T, k, n) .- T(0.5), zero(T))
+        X = Wg * Hg
+        W = Wg .+ rand(T, p, k)*T(0.1)
+        NMF.solve!(NMF.CoordinateDescent{T}(α=0.0, maxiter=1000, tol=1e-9), X, W, Hg)
+        @test X ≈ W * Hg atol=1e-4
 
-    # Regularization
-    Wg = max.(rand(T, p, k) .- T(0.5), zero(T))
-    Hg = max.(rand(T, k, n) .- T(0.5), zero(T))
-    X = Wg * Hg
-    W = Wg .+ rand(T, p, k)*T(0.1)
-    NMF.solve!(NMF.CoordinateDescent{T}(α=1e-4, l₁ratio=0.5, shuffle=true, maxiter=1000, tol=1e-9), X, W, Hg)
-    @test X ≈ W * Hg atol=1e-2
+        # Regularization
+        Wg = max.(rand(T, p, k) .- T(0.5), zero(T))
+        Hg = max.(rand(T, k, n) .- T(0.5), zero(T))
+        X = Wg * Hg
+        W = Wg .+ rand(T, p, k)*T(0.1)
+        NMF.solve!(NMF.CoordinateDescent{T}(α=1e-4, l₁ratio=0.5, shuffle=true, maxiter=1000, tol=1e-9), X, W, Hg)
+        @test X ≈ W * Hg atol=1e-2
+    end
 end

--- a/test/greedycd.jl
+++ b/test/greedycd.jl
@@ -1,27 +1,26 @@
 # some tests for GreedyCD
 
-p = 5
-n = 8
-k = 3
+@testset "greedycd" begin
+    p = 5
+    n = 8
+    k = 3
 
-Random.seed!(1234)
+    for T in (Float64, Float32)
+        for lambda_w in (0.0, 1e-5)
+            for lambda_h in (0.0, 1e-5)
+                Wg = max.(rand(T, p, k) .- T(0.5), zero(T))
+                Hg = max.(rand(T, k, n) .- T(0.5), zero(T))
+                X = Wg * Hg
+                W = Wg .+ rand(T, p, k) * T(0.1)
 
-for T in (Float64, Float32)
-    for lambda_w in (0.0, 1e-5)
-        for lambda_h in (0.0, 1e-5)
-            Wg = max.(rand(T, p, k) .- T(0.5), zero(T))
-            Hg = max.(rand(T, k, n) .- T(0.5), zero(T))
-            X = Wg * Hg
-            W = Wg .+ rand(T, p, k) * T(0.1)
+                NMF.solve!(NMF.GreedyCD{T}(maxiter=1000, tol=1e-9, lambda_w=lambda_w, lambda_h=lambda_h), X, W, Hg)
 
-            NMF.solve!(NMF.GreedyCD{T}(maxiter=1000, tol=1e-9, lambda_w=lambda_w, lambda_h=lambda_h), X, W, Hg)
-
-            @test all(W .>= zero(T))
-            @test all(Hg .>= zero(T))
-            @test !any(isnan.(W))
-            @test !any(isnan.(Hg))
-            @test X ≈ W * Hg atol = 1e-3
+                @test all(W .>= zero(T))
+                @test all(Hg .>= zero(T))
+                @test !any(isnan.(W))
+                @test !any(isnan.(Hg))
+                @test X ≈ W * Hg atol = 1e-3
+            end
         end
     end
 end
-

--- a/test/initialization.jl
+++ b/test/initialization.jl
@@ -1,47 +1,49 @@
 # test initilization functions
 
-for T in (Float64, Float32)
+@testset "initialization" begin
+    for T in (Float64, Float32)
 
-    X = rand(T, 8, 12)
+        X = rand(T, 8, 12)
 
-    # randinit
+        # randinit
 
-    W, H = NMF.randinit(X, 5)
-    @test size(W) == (8, 5)
-    @test size(H) == (5, 12)
-    @test all(W .>= zero(T))
-    @test all(H .>= zero(T))
+        W, H = NMF.randinit(X, 5)
+        @test size(W) == (8, 5)
+        @test size(H) == (5, 12)
+        @test all(W .>= zero(T))
+        @test all(H .>= zero(T))
 
-    W, H = NMF.randinit(X, 5; zeroh=true)
-    @test size(W) == (8, 5)
-    @test size(H) == (5, 12)
-    @test all(W .>= zero(T))
-    @test all(H .== zero(T))
+        W, H = NMF.randinit(X, 5; zeroh=true)
+        @test size(W) == (8, 5)
+        @test size(H) == (5, 12)
+        @test all(W .>= zero(T))
+        @test all(H .== zero(T))
 
-    W, H = NMF.randinit(X, 5; normalize=true)
-    @test size(W) == (8, 5)
-    @test size(H) == (5, 12)
-    @test all(W .>= zero(T))
-    @test all(H .>= zero(T))
-    @test vec(sum(W, dims=1)) ≈ ones(5)
+        W, H = NMF.randinit(X, 5; normalize=true)
+        @test size(W) == (8, 5)
+        @test size(H) == (5, 12)
+        @test all(W .>= zero(T))
+        @test all(H .>= zero(T))
+        @test vec(sum(W, dims=1)) ≈ ones(5)
 
-    ## nndsvd
+        ## nndsvd
 
-    Random.seed!(5678)
-    W, H = NMF.nndsvd(X, 5)
-    @test size(W) == (8, 5)
-    @test size(H) == (5, 12)
-    @test all(W .>= zero(T))
-    @test all(H .>= zero(T))
+        Random.seed!(5678)
+        W, H = NMF.nndsvd(X, 5)
+        @test size(W) == (8, 5)
+        @test size(H) == (5, 12)
+        @test all(W .>= zero(T))
+        @test all(H .>= zero(T))
 
-    Random.seed!(5678)
-    W2, H2 = NMF.nndsvd(X, 5; zeroh=true)
-    @test size(W) == (8, 5)
-    @test size(H) == (5, 12)
-    @test all(W2 .== W)
-    @test all(H2 .== zero(T))
+        Random.seed!(5678)
+        W2, H2 = NMF.nndsvd(X, 5; zeroh=true)
+        @test size(W) == (8, 5)
+        @test size(H) == (5, 12)
+        @test all(W2 .== W)
+        @test all(H2 .== zero(T))
 
-    W, H = NMF.nndsvd(X, 5; variant=:ar)
-    @test all(W .> zero(T))
-    # NMF.printf_mat(W)
+        W, H = NMF.nndsvd(X, 5; variant=:ar)
+        @test all(W .> zero(T))
+        # NMF.printf_mat(W)
+    end
 end

--- a/test/interf.jl
+++ b/test/interf.jl
@@ -1,33 +1,33 @@
-Random.seed!(5678)
+@testset "interf" begin
+    p = 5
+    n = 8
+    k = 3
 
-p = 5
-n = 8
-k = 3
+    for T in (Float64, Float32)
+        Wg = max.(rand(T, p, k) .- T(0.3), zero(T))
+        Hg = max.(rand(T, k, n) .- T(0.3), zero(T))
+        X = Wg * Hg
 
-for T in (Float64, Float32)
-    Wg = max.(rand(T, p, k) .- T(0.3), zero(T))
-    Hg = max.(rand(T, k, n) .- T(0.3), zero(T))
-    X = Wg * Hg
-
-    for alg in (:multmse, :multdiv, :projals, :alspgrad, :cd, :greedycd)
-        for init in (:random, :nndsvd, :nndsvda, :nndsvdar, :spa)
-            ret = NMF.nnmf(X, k, alg=alg, init=init)
+        for alg in (:multmse, :multdiv, :projals, :alspgrad, :cd, :greedycd)
+            for init in (:random, :nndsvd, :nndsvda, :nndsvdar, :spa)
+                ret = NMF.nnmf(X, k, alg=alg, init=init)
+            end
         end
-    end
 
-    # replicates test
-    rep = NMF.nnmf(X, k, replicates=10, maxiter=10, alg=:multmse)
-    ret = NMF.nnmf(X, k, W0=rep.W, H0=rep.H, init=:custom)
+        # replicates test
+        rep = NMF.nnmf(X, k, replicates=10, maxiter=10, alg=:multmse)
+        ret = NMF.nnmf(X, k, W0=rep.W, H0=rep.H, init=:custom)
 
-    # spa test 
-    ret = NMF.nnmf(X, k, alg=:spa, init=:spa)
+        # spa test
+        ret = NMF.nnmf(X, k, alg=:spa, init=:spa)
 
-    # update_H test
-    W = max.(rand(T, p, k) .- T(0.3), zero(T))
-    H = max.(rand(T, k, n) .- T(0.3), zero(T))
-    for alg in (:multmse, :multdiv, :projals, :alspgrad, :cd, :greedycd)
-        ret = NMF.nnmf(X, k, alg=alg, init=:custom, W0=copy(W), H0=copy(H), update_H=false)
-        @test all(H .== ret.H)
-        @test any(W .!= ret.W)
+        # update_H test
+        W = max.(rand(T, p, k) .- T(0.3), zero(T))
+        H = max.(rand(T, k, n) .- T(0.3), zero(T))
+        for alg in (:multmse, :multdiv, :projals, :alspgrad, :cd, :greedycd)
+            ret = NMF.nnmf(X, k, alg=alg, init=:custom, W0=copy(W), H0=copy(H), update_H=false)
+            @test all(H .== ret.H)
+            @test any(W .!= ret.W)
+        end
     end
 end

--- a/test/multupd.jl
+++ b/test/multupd.jl
@@ -1,27 +1,27 @@
 # some tests for MultUpdate
 
-p = 5
-n = 8
-k = 3
+@testset "multupd" begin
+    p = 5
+    n = 8
+    k = 3
 
-Random.seed!(5678)
+    for T in (Float64, Float32)
+        for alg in (:mse, :div)
+            for lambda_w in (0.0, 1e-4)
+                for lambda_h in (0.0, 1e-4)
+                    Wg = max.(rand(T, p, k) .- T(0.5), zero(T))
+                    Hg = max.(rand(T, k, n) .- T(0.5), zero(T))
+                    X = Wg * Hg
+                    W = Wg .+ rand(T, p, k)*T(0.1)
 
-for T in (Float64, Float32)
-    for alg in (:mse, :div)
-        for lambda_w in (0.0, 1e-4)
-            for lambda_h in (0.0, 1e-4)
-                Wg = max.(rand(T, p, k) .- T(0.5), zero(T))
-                Hg = max.(rand(T, k, n) .- T(0.5), zero(T))
-                X = Wg * Hg
-                W = Wg .+ rand(T, p, k)*T(0.1)
+                    NMF.solve!(NMF.MultUpdate{T}(obj=alg, maxiter=5000, tol=1e-9, lambda_w=lambda_w, lambda_h=lambda_h), X, W, Hg)
 
-                NMF.solve!(NMF.MultUpdate{T}(obj=alg, maxiter=5000, tol=1e-9, lambda_w=lambda_w, lambda_h=lambda_h), X, W, Hg)
-                
-                @test all(W .>= zero(T))
-                @test all(Hg .>= zero(T))
-                @test !any(isnan.(W)) 
-                @test !any(isnan.(Hg)) 
-                @test X ≈ W * Hg atol=1e-2
+                    @test all(W .>= zero(T))
+                    @test all(Hg .>= zero(T))
+                    @test !any(isnan.(W))
+                    @test !any(isnan.(Hg))
+                    @test X ≈ W * Hg atol=1e-2
+                end
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,15 +7,16 @@ using StatsBase
 tests = ["utils",
          "initialization",
          "spa",
-         "multupd", 
+         "multupd",
          "alspgrad",
          "coorddesc",
          "greedycd",
          "interf"]
 
 println("Running tests:")
-for t in tests
-    tp = "$t.jl"
-    println("* $tp ...")
-    include(tp)
+@testset "All tests" begin
+    for t in tests
+        tp = "$t.jl"
+        include(tp)
+    end
 end

--- a/test/spa.jl
+++ b/test/spa.jl
@@ -1,33 +1,32 @@
 # some tests for spa
 
 # data
+@testset "spa" begin
+    p = 15
+    n = 8
+    k = 2
 
-Random.seed!(5678)
+    # Matrices
+    for T in (Float64, Float32)
+        # Initialization test
+        ϵ = eps(T)^(1/4)
+        Wg = max.(rand(T, p, k) .- T(0.3), T(ϵ))
+        Hg = max.(rand(T, k, n) .- T(0.3), T(ϵ))
+        X = Wg * Hg
+        w, h = NMF.spa(X, k)
+        x = w * h
+        @test all(w .>= zero(T))
+        @test all(h .>= zero(T))
+        @test x ≈ X atol=10.0*ϵ
+        #println("ϵ =",ϵ," while ||x .- X||= ",maximum(abs.(x .- X)))
 
-p = 15
-n = 8
-k = 2
-
-# Matrices
-for T in (Float64, Float32)
-    # Initialization test
-    ϵ = eps(T)^(1/4)  
-    Wg = max.(rand(T, p, k) .- T(0.3), T(ϵ))
-    Hg = max.(rand(T, k, n) .- T(0.3), T(ϵ))
-    X = Wg * Hg
-    w, h = NMF.spa(X, k)
-    x = w * h
-    @test all(w .>= zero(T))
-    @test all(h .>= zero(T))
-    @test x ≈ X atol=10.0*ϵ
-    #println("ϵ =",ϵ," while ||x .- X||= ",maximum(abs.(x .- X)))
-
-    # Separability test
-    Wg, Hg = NMF.separable_data(p, n, k)
-    X = Wg * Hg
-    w, h = NMF.spa(X, k)
-    x = w * h
-    @test all(w .>= zero(T))
-    @test all(h .>= zero(T))
-    @test sqL2dist(X, x) < eps(T)
+        # Separability test
+        Wg, Hg = NMF.separable_data(p, n, k)
+        X = Wg * Hg
+        w, h = NMF.spa(X, k)
+        x = w * h
+        @test all(w .>= zero(T))
+        @test all(h .>= zero(T))
+        @test sqL2dist(X, x) < eps(T)
+    end
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,62 +1,64 @@
 # Test internal utilities functions
 
-make_pdmat(n::Int) = (g = randn(n, n); NMF.adddiag!(g'g, 0.1))
+@testset "utils" begin
+    make_pdmat(n::Int) = (g = randn(n, n); NMF.adddiag!(g'g, 0.1))
 
-## adddiag!
+    ## adddiag!
 
-a0 = rand(3, 3)
-a = copy(a0)
+    a0 = rand(3, 3)
+    a = copy(a0)
 
-NMF.adddiag!(a, 0.)
-@test a == a0
+    NMF.adddiag!(a, 0.)
+    @test a == a0
 
-NMF.adddiag!(a, 2.5)
-@test a == a0 + 2.5I
+    NMF.adddiag!(a, 2.5)
+    @test a == a0 + 2.5I
 
-## normalize1!
+    ## normalize1!
 
-a = rand(5)
-NMF.normalize1!(a)
-@test sum(a) ≈ 1.0
+    a = rand(5)
+    NMF.normalize1!(a)
+    @test sum(a) ≈ 1.0
 
-## normalize1_cols!
+    ## normalize1_cols!
 
-a = rand(5, 6)
-NMF.normalize1_cols!(a)
-@test vec(sum(a, dims=1)) ≈ ones(6)
+    a = rand(5, 6)
+    NMF.normalize1_cols!(a)
+    @test vec(sum(a, dims=1)) ≈ ones(6)
 
-## projectnn!
+    ## projectnn!
 
-a0 = randn(5, 5)
-a = copy(a0)
-NMF.projectnn!(a)
-@test a == max.(a0, 0.0)
+    a0 = randn(5, 5)
+    a = copy(a0)
+    NMF.projectnn!(a)
+    @test a == max.(a0, 0.0)
 
-## posneg!
+    ## posneg!
 
-a = randn(5, 5)
-ac = copy(a)
-ap = zeros(size(a))
-an = zeros(size(a))
+    a = randn(5, 5)
+    ac = copy(a)
+    ap = zeros(size(a))
+    an = zeros(size(a))
 
-NMF.posneg!(a, ap, an)
-@test a == ac
-@test ap == max.(a, 0.0)
-@test an == max.(-a, 0.0)
+    NMF.posneg!(a, ap, an)
+    @test a == ac
+    @test ap == max.(a, 0.0)
+    @test an == max.(-a, 0.0)
 
-## pdsolve!
+    ## pdsolve!
 
-A = make_pdmat(5)
-X = rand(5, 3)
-Y = A * X
-NMF.pdsolve!(A, Y)
-@test X ≈ Y
+    A = make_pdmat(5)
+    X = rand(5, 3)
+    Y = A * X
+    NMF.pdsolve!(A, Y)
+    @test X ≈ Y
 
-## pdrsolve!
+    ## pdrsolve!
 
-B = make_pdmat(5)
-X = rand(4, 5)
-Y = X * B
-Xr = zeros(4, 5)
-NMF.pdrsolve!(Y, B, Xr)
-@test Xr ≈ X
+    B = make_pdmat(5)
+    X = rand(4, 5)
+    Y = X * B
+    Xr = zeros(4, 5)
+    NMF.pdrsolve!(Y, B, Xr)
+    @test Xr ≈ X
+end


### PR DESCRIPTION
This may make the tests more reproducible, since we set the seed inside a `@testset`. See https://github.com/JuliaStats/NMF.jl/pull/70#issuecomment-1396090714

Note that the random number generator is not guaranteed to give the same sequence across all Julia versions, so version-specific failures are still possible, but at least they should be reproducible.

It will also fix a (repeated) warning:
```
┌ Warning: Assignment to `X` in soft scope is ambiguous because a global variable by the same name exists: `X` will be treated as a new local. Disambiguate by using `local X` to suppress this warning or `global X` to assign to the existing global variable.
└ @ ~/.julia/dev/NMF/test/alspgrad.jl:15
```