### PR TITLE
Use fixed matrices in tests

### DIFF
--- a/test/alspgrad.jl
+++ b/test/alspgrad.jl
@@ -1,27 +1,20 @@
 # some tests for ALSPGrad
 
 @testset "alspgrad" begin
-    # data
-    p = 5
-    n = 8
-    k = 3
-
     # Matrices
     for T in (Float64, Float32)
-        Wg = max.(rand(T, p, k) .- T(0.3), zero(T))
-        Hg = max.(rand(T, k, n) .- T(0.3), zero(T))
-        X = Wg * Hg
+        X, Wg, Hg = laurberg6x3(T(0.3))
 
         # test update of H
 
-        H = rand(T, k, n)
+        H = rand(T, size(Hg)...)
         NMF.alspgrad_updateh!(X, Wg, H; maxiter=1000, tolg=eps(T))
         @test all(H .>= zero(T))
         @test H ≈ Hg atol=eps(T)^(1/4)
 
         # test update of W
 
-        W = rand(T, p, k)
+        W = rand(T, size(Wg)...)
         NMF.alspgrad_updatew!(X, W, Hg; maxiter=1000, tolg=eps(T))
         @test all(W .>= zero(T))
         @test W ≈ Wg atol=eps(T)^(1/4)

--- a/test/coorddesc.jl
+++ b/test/coorddesc.jl
@@ -1,23 +1,15 @@
 # some tests for CoordinateDescent
 
 @testset "coorddesc" begin
-    p = 5
-    n = 8
-    k = 3
-
     for T in (Float64, Float32)
-        Wg = max.(rand(T, p, k) .- T(0.5), zero(T))
-        Hg = max.(rand(T, k, n) .- T(0.5), zero(T))
-        X = Wg * Hg
-        W = Wg .+ rand(T, p, k)*T(0.1)
+        X, Wg, Hg = laurberg6x3(T(0.3))
+        W = Wg .+ rand(T, size(Wg)...)*T(0.1)
         NMF.solve!(NMF.CoordinateDescent{T}(α=0.0, maxiter=1000, tol=1e-9), X, W, Hg)
         @test X ≈ W * Hg atol=1e-4
 
         # Regularization
-        Wg = max.(rand(T, p, k) .- T(0.5), zero(T))
-        Hg = max.(rand(T, k, n) .- T(0.5), zero(T))
-        X = Wg * Hg
-        W = Wg .+ rand(T, p, k)*T(0.1)
+        X, Wg, Hg = laurberg6x3(T(0.3))
+        W = Wg .+ rand(T, size(Wg)...)*T(0.1)
         NMF.solve!(NMF.CoordinateDescent{T}(α=1e-4, l₁ratio=0.5, shuffle=true, maxiter=1000, tol=1e-9), X, W, Hg)
         @test X ≈ W * Hg atol=1e-2
     end

--- a/test/greedycd.jl
+++ b/test/greedycd.jl
@@ -1,17 +1,12 @@
 # some tests for GreedyCD
 
 @testset "greedycd" begin
-    p = 5
-    n = 8
-    k = 3
 
     for T in (Float64, Float32)
         for lambda_w in (0.0, 1e-5)
             for lambda_h in (0.0, 1e-5)
-                Wg = max.(rand(T, p, k) .- T(0.5), zero(T))
-                Hg = max.(rand(T, k, n) .- T(0.5), zero(T))
-                X = Wg * Hg
-                W = Wg .+ rand(T, p, k) * T(0.1)
+                X, Wg, Hg = laurberg6x3(T(0.3))
+                W = Wg .+ rand(T, size(Wg)...)*T(0.1)
 
                 NMF.solve!(NMF.GreedyCD{T}(maxiter=1000, tol=1e-9, lambda_w=lambda_w, lambda_h=lambda_h), X, W, Hg)
 

--- a/test/multupd.jl
+++ b/test/multupd.jl
@@ -1,18 +1,12 @@
 # some tests for MultUpdate
 
 @testset "multupd" begin
-    p = 5
-    n = 8
-    k = 3
-
     for T in (Float64, Float32)
         for alg in (:mse, :div)
             for lambda_w in (0.0, 1e-4)
                 for lambda_h in (0.0, 1e-4)
-                    Wg = max.(rand(T, p, k) .- T(0.5), zero(T))
-                    Hg = max.(rand(T, k, n) .- T(0.5), zero(T))
-                    X = Wg * Hg
-                    W = Wg .+ rand(T, p, k)*T(0.1)
+                    X, Wg, Hg = laurberg6x3(T(0.3))
+                    W = Wg .+ rand(T, size(Wg)...)*T(0.1)
 
                     NMF.solve!(NMF.MultUpdate{T}(obj=alg, maxiter=5000, tol=1e-9, lambda_w=lambda_w, lambda_h=lambda_h), X, W, Hg)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,8 @@ using Random
 using LinearAlgebra
 using StatsBase
 
+include("testproblems.jl")
+
 tests = ["utils",
          "initialization",
          "spa",

--- a/test/testproblems.jl
+++ b/test/testproblems.jl
@@ -1,0 +1,13 @@
+# Hans Laurberg, Mads Græsbøll Christensen, Mark D. Plumbley, Lars Kai Hansen,
+# Søren Holdt Jensen, "Theorems on Positive Data: On the Uniqueness of NMF",
+# Computational Intelligence and Neuroscience, vol. 2008, Article ID 764206, 9
+# pages, 2008. https://doi.org/10.1155/2008/764206
+# Example 3 from Section 5, Eqs. 9 (for α = 0.1 or α = 0.3, the NMF is unique up to scaling)
+function laurberg6x3(α)
+    H = [α 1 1 α 0 0
+         1 α 0 0 α 1
+         0 0 α 1 1 α]
+    W = H'
+    X = W*H
+    return X, Matrix(W), H
+end


### PR DESCRIPTION
This switches tests to use an example with known-unique
NMF factorization. Fixes #73.

Example matrix is from [here](https://www.hindawi.com/journals/cin/2008/764206/#ex3).