### PR TITLE
SnoopPrecomple -> PrecompileTools

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,22 +1,22 @@
 name = "NMF"
 uuid = "6ef6ca0d-6ad7-5ff6-b225-e928bfa0a386"
 license = "MIT"
-version = "1.0.1"
+version = "1.0.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NonNegLeastSquares = "b7351bd1-99d9-5c5d-8786-f205a815c4d7"
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RandomizedLinAlg = "0448d7d9-159c-5637-8537-fd72090fea46"
-SnoopPrecompile = "66db9d55-30c0-4569-8b51-7e840670fc0c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 NonNegLeastSquares = "0.2.0, 0.3.0, 0.4.0"
 RandomizedLinAlg = "0.1.0"
-SnoopPrecompile = "1"
+PrecompileTools = "1"
 StatsBase = "0.25, 0.26, 0.27, 0.28, 0.29, 0.30, 0.31, 0.32, 0.33, 0.34"
 julia = "1.6"
 

--- a/src/NMF.jl
+++ b/src/NMF.jl
@@ -22,12 +22,12 @@ module NMF
 
     include("interf.jl")
 
-    using SnoopPrecompile
+    using PrecompileTools
 
     let
-        @precompile_setup begin
+        @setup_workload begin
             X = rand(8, 6)
-            @precompile_all_calls begin
+            @compile_workload begin
                 for alg in (:multmse, :multdiv, :projals, :alspgrad, :cd, :greedycd)
                     for init in (:random, :nndsvd, :nndsvda, :nndsvdar, :spa)
                         nnmf(X, 4, alg=alg, init=init)


### PR DESCRIPTION
SnoopPrecompile is effectively deprecated.

A while ago I submitted a mass pull request job, but the script I wrote inadvertently missed packages I had previously contributed to.