### PR TITLE
New stop condition: use component relative change

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -65,10 +65,7 @@ function nmf_skeleton!(updater::NMFUpdater{T},
         update_wh!(updater, state, X, W, H)
 
         # determine convergence
-        dev = max(maxad(preW, W), maxad(preH, H))
-        if dev < tol
-            converged = true
-        end
+        converged = stop_condition(W, preW, H, preH, tol)
 
         # display info
         if verbose
@@ -84,4 +81,24 @@ function nmf_skeleton!(updater::NMFUpdater{T},
         objv = evaluate_objv(updater, state, X, W, H)
     end
     return Result{T}(W, H, t, converged, objv)
+end
+
+
+function stop_condition(W::AbstractArray{T}, preW::AbstractArray, H::AbstractArray, preH::AbstractArray, eps::AbstractFloat) where T
+    for j in axes(W,2)
+        dev_w = sum_w = zero(T)
+        for i in axes(W,1)
+            dev_w += (W[i,j] - preW[i,j])^2
+            sum_w += (W[i,j] + preW[i,j])^2
+        end
+        dev_h = sum_h = zero(T)
+        for i in axes(H,2)
+            dev_h += (H[j,i] - preH[j,i])^2
+            sum_h += (H[j,i] + preH[j,i])^2
+        end  
+        if sqrt(dev_w) > eps*sqrt(sum_w) || sqrt(dev_h) > eps*sqrt(sum_h)
+            return false
+        end 
+    end
+    return true    
 end


### PR DESCRIPTION
Previously, convergence was achieved when `|W[i, j]-preW[i, j]|<=tol for all i, j`.

Running NMF on `10*X`  (where `X` is the data matrix ) would increase the number of iterations compared to NMF on `X`. Now, `||W[:, j]-preW[:, j]||/||W[:, j]+preW[:, j]||<=tol for all j` is the new convergence criterion, which is relative difference rather absolute difference and thus, it is scale invariant.

This might be a breaking change but it is unclear. 

This new criterion is more similar to the the stop condition in [`sklearn.decomposition.NMF`](https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.NMF.html#sklearn-decomposition-nmf)