### PR TITLE
Add a link to NMFMerge

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ A Julia package for non-negative matrix factorization (NMF).
 
 - Probabilistic NMF
 
+See also [NMFMerge](https://github.com/HolyLab/NMFMerge.jl), which can augment any least-squares NMF algorithm.
 
 ## Overview
 


### PR DESCRIPTION
Since the README invites additional contributions, this seems relevant. It doesn't fit neatly into the API of this package, which is why it's a separate repository (it's really an additional layer on top of a core NMF algorithm).

CC @youdongguo 