### PR TITLE
optimize hals update to matrix multiplication

### DIFF
--- a/src/coorddesc.jl
+++ b/src/coorddesc.jl
@@ -84,8 +84,8 @@ mutable struct CoordinateDescentState{T}
     HHt::Matrix{T}
     XHt::Matrix{T}
     XtW::Matrix{T}
-    WHHt::Matrix{T}
-    HtWtW::Matrix{T}
+    WHHt_j::Matrix{T}
+    HtWtW_j::Matrix{T}
     violation::T
     violation_init::Union{Nothing, T}
     
@@ -95,8 +95,8 @@ mutable struct CoordinateDescentState{T}
                Matrix{T}(undef, k, k),
                Matrix{T}(undef, p, k),
                Matrix{T}(undef, n, k),
-               Matrix{T}(undef, p, k),
-               Matrix{T}(undef, n, k),
+               Matrix{T}(undef, p, 1),
+               Matrix{T}(undef, n, 1),
                violation, 
                violation_init)
     end
@@ -117,10 +117,10 @@ function _update_coord_descent!(s::CoordinateDescentState{T}, X, W, H,
     mul!(HHt, H, Ht)
     if W_flag
         XHt = s.XHt
-        WHHt = s.WHHt
+        WHHt_j = s.WHHt_j
     else
         XHt = s.XtW
-        WHHt = s.HtWtW
+        WHHt_j = s.HtWtW_j
     end
     mul!(XHt, X, Ht)
 
@@ -142,10 +142,10 @@ function _update_coord_descent!(s::CoordinateDescentState{T}, X, W, H,
     violation = zero(eltype(X))
 
     for t in permutation
-        mul!(WHHt, W, HHt)
+        mul!(WHHt_j, W, view(HHt, :, t))
         for i in 1:n_samples
              # gradient = GW[t, i] where GW = np.dot(W, HHt) - XHt
-            grad = -XHt[i, t] + WHHt[i, t]
+            grad = -XHt[i, t] + WHHt_j[i]
 
             # projected gradient
             pg = W[i, t] == 0 ? min(zero(grad), grad) : grad

--- a/src/coorddesc.jl
+++ b/src/coorddesc.jl
@@ -84,13 +84,17 @@ mutable struct CoordinateDescentState{T}
     HHt::Matrix{T}
     XHt::Matrix{T}
     XtW::Matrix{T}
+    WHHt::Matrix{T}
+    HtWtW::Matrix{T}
     violation::T
     violation_init::Union{Nothing, T}
     
     function CoordinateDescentState{T}(X, W, H, violation, violation_init) where T
         p, n, k = nmf_checksize(X, W, H)
-        new{T}(W * H, 
+        new{T}(W * H,    
                Matrix{T}(undef, k, k),
+               Matrix{T}(undef, p, k),
+               Matrix{T}(undef, n, k),
                Matrix{T}(undef, p, k),
                Matrix{T}(undef, n, k),
                violation, 
@@ -113,8 +117,10 @@ function _update_coord_descent!(s::CoordinateDescentState{T}, X, W, H,
     mul!(HHt, H, Ht)
     if W_flag
         XHt = s.XHt
+        WHHt = s.WHHt
     else
         XHt = s.XtW
+        WHHt = s.HtWtW
     end
     mul!(XHt, X, Ht)
 
@@ -136,13 +142,10 @@ function _update_coord_descent!(s::CoordinateDescentState{T}, X, W, H,
     violation = zero(eltype(X))
 
     for t in permutation
+        mul!(WHHt, W, HHt)
         for i in 1:n_samples
              # gradient = GW[t, i] where GW = np.dot(W, HHt) - XHt
-            grad = -XHt[i, t]
-
-            for r in 1:n_components
-                grad += HHt[t, r] * W[i, r]
-            end
+            grad = -XHt[i, t] + WHHt[i, t]
 
             # projected gradient
             pg = W[i, t] == 0 ? min(zero(grad), grad) : grad
@@ -155,6 +158,7 @@ function _update_coord_descent!(s::CoordinateDescentState{T}, X, W, H,
             end
         end
     end
+
     return violation
 end
 


### PR DESCRIPTION
Change the update rule of HALS to matrix multiplication. It is the same equation as the old version but the old one update W and H element by element 