### PR TITLE
Limit struct mutability

### DIFF
--- a/src/alspgrad.jl
+++ b/src/alspgrad.jl
@@ -349,7 +349,7 @@ end
 
 ## main algorithm
 
-mutable struct ALSPGrad{T}
+struct ALSPGrad{T}
     maxiter::Int      # maximum number of main iterations
     maxsubiter::Int   # maximum number of iterations within a sub-routine
     tol::T            # tolerance of changes on W & H (main)
@@ -373,8 +373,8 @@ mutable struct ALSPGrad{T}
 end
 
 mutable struct ALSPGradUpd{T} <: NMFUpdater{T}
-    update_H::Bool
-    maxsubiter::Int
+    const update_H::Bool
+    const maxsubiter::Int
     tolg::T
 end
 

--- a/src/coorddesc.jl
+++ b/src/coorddesc.jl
@@ -21,7 +21,7 @@
 #  computer sciences 92.3: 708-721, 2009.
 
 
-mutable struct CoordinateDescent{T}
+struct CoordinateDescent{T}
     maxiter::Int           # maximum number of iterations (in main procedure)
     verbose::Bool          # whether to show procedural information
     tol::T                 # tolerance of changes on W and H upon convergence
@@ -80,10 +80,10 @@ struct CoordinateDescentUpd{T} <: NMFUpdater{T}
 end
 
 mutable struct CoordinateDescentState{T}
-    WH::Matrix{T}
-    HHt::Matrix{T}
-    XHt::Matrix{T}
-    XtW::Matrix{T}
+    const WH::Matrix{T}
+    const HHt::Matrix{T}
+    const XHt::Matrix{T}
+    const XtW::Matrix{T}
     violation::T
     violation_init::Union{Nothing, T}
     

--- a/src/greedycd.jl
+++ b/src/greedycd.jl
@@ -7,7 +7,7 @@
 #  the 17th ACM SIGKDD International Conference on Knowledge Discovery and Data Mining, 
 #  pp. 1064–1072, 2011.
 
-mutable struct GreedyCD{T}
+struct GreedyCD{T}
     maxiter::Int           # maximum number of iterations (in main procedure)
     verbose::Bool          # whether to show procedural information
     tol::T                 # tolerance of changes on W and H upon convergence

--- a/src/multupd.jl
+++ b/src/multupd.jl
@@ -6,7 +6,7 @@
 #   Matrix Factorization. Advances in NIPS, 2001.
 #
 
-mutable struct MultUpdate{T}
+struct MultUpdate{T}
     obj::Symbol                 # objective :mse or :div
     maxiter::Int                # maximum number of iterations
     verbose::Bool               # whether to show procedural information

--- a/src/projals.jl
+++ b/src/projals.jl
@@ -12,7 +12,7 @@
 #  negative entries back to zeros.
 #
 
-mutable struct ProjectedALS{T}
+struct ProjectedALS{T}
     maxiter::Int            # maximum number of iterations (in main procedure)
     verbose::Bool           # whether to show procedural information
     tol::T                  # tolerance of changes on W and H upon convergence

--- a/src/spa.jl
+++ b/src/spa.jl
@@ -5,7 +5,7 @@
 #   IEEE Transactions on Pattern Analysis and Machine Intelligence, 
 #   vol. 36, no. 4, pp. 698-714, 2013. 
 
-mutable struct SPA{T}
+struct SPA{T}
     obj::Symbol   # objective :mse or :div
 
     function SPA{T}(;obj=:mse) where T


### PR DESCRIPTION
`master` has quite a few `mutable struct`s, but not all fields need to be mutated. This converts some to immutable and marks other fields `const`. This helps the compiler emit more optimized code and also guards against unintended errors.