### PR TITLE
Add AbstractNMFAlgorithm supertype; drop unused SPA type parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,5 +343,5 @@ import NMF
 W, H = NMF.spa(X, 5)
 
  # optimize
-NMF.solve!(NMF.SPA{Float64}(obj=:mse), X, W, H)
+NMF.solve!(NMF.SPA(obj=:mse), X, W, H)
 ```

--- a/src/alspgrad.jl
+++ b/src/alspgrad.jl
@@ -349,7 +349,7 @@ end
 
 ## main algorithm
 
-struct ALSPGrad{T}
+struct ALSPGrad{T} <: AbstractNMFAlgorithm
     maxiter::Int      # maximum number of main iterations
     maxsubiter::Int   # maximum number of iterations within a sub-routine
     tol::T            # tolerance of changes on W & H (main)

--- a/src/common.jl
+++ b/src/common.jl
@@ -16,6 +16,17 @@ function nmf_checksize(X, W::AbstractMatrix, H::AbstractMatrix)
 end
 
 
+# algorithm specifications
+
+"""
+    AbstractNMFAlgorithm
+
+Supertype for NMF algorithm specifications. Each concrete subtype bundles the
+options for one factorization algorithm; an instance is run with `solve!`.
+"""
+abstract type AbstractNMFAlgorithm end
+
+
 # the result type
 
 struct Result{T}

--- a/src/coorddesc.jl
+++ b/src/coorddesc.jl
@@ -21,7 +21,7 @@
 #  computer sciences 92.3: 708-721, 2009.
 
 
-struct CoordinateDescent{T}
+struct CoordinateDescent{T} <: AbstractNMFAlgorithm
     maxiter::Int           # maximum number of iterations (in main procedure)
     verbose::Bool          # whether to show procedural information
     tol::T                 # tolerance of changes on W and H upon convergence

--- a/src/greedycd.jl
+++ b/src/greedycd.jl
@@ -7,7 +7,7 @@
 #  the 17th ACM SIGKDD International Conference on Knowledge Discovery and Data Mining, 
 #  pp. 1064–1072, 2011.
 
-struct GreedyCD{T}
+struct GreedyCD{T} <: AbstractNMFAlgorithm
     maxiter::Int           # maximum number of iterations (in main procedure)
     verbose::Bool          # whether to show procedural information
     tol::T                 # tolerance of changes on W and H upon convergence

--- a/src/interf.jl
+++ b/src/interf.jl
@@ -74,7 +74,7 @@ function nnmf(X::AbstractMatrix{T}, k::Integer;
         if init != :spa
             throw(ArgumentError("Invalid value for init, use :spa instead."))
         end
-        ret = solve_replicates!(SPA{T}(obj=:mse), X, W, H; replicates, initH)
+        ret = solve_replicates!(SPA(obj=:mse), X, W, H; replicates, initH)
     else
         throw(ArgumentError("Invalid algorithm."))
     end

--- a/src/multupd.jl
+++ b/src/multupd.jl
@@ -6,7 +6,7 @@
 #   Matrix Factorization. Advances in NIPS, 2001.
 #
 
-struct MultUpdate{T}
+struct MultUpdate{T} <: AbstractNMFAlgorithm
     obj::Symbol                 # objective :mse or :div
     maxiter::Int                # maximum number of iterations
     verbose::Bool               # whether to show procedural information

--- a/src/projals.jl
+++ b/src/projals.jl
@@ -12,7 +12,7 @@
 #  negative entries back to zeros.
 #
 
-struct ProjectedALS{T}
+struct ProjectedALS{T} <: AbstractNMFAlgorithm
     maxiter::Int            # maximum number of iterations (in main procedure)
     verbose::Bool           # whether to show procedural information
     tol::T                  # tolerance of changes on W and H upon convergence

--- a/src/spa.jl
+++ b/src/spa.jl
@@ -5,12 +5,12 @@
 #   IEEE Transactions on Pattern Analysis and Machine Intelligence, 
 #   vol. 36, no. 4, pp. 698-714, 2013. 
 
-struct SPA{T}
+struct SPA <: AbstractNMFAlgorithm
     obj::Symbol   # objective :mse or :div
 
-    function SPA{T}(;obj=:mse) where T
+    function SPA(;obj=:mse)
         obj == :mse || obj == :div || throw(ArgumentError("Invalid value for obj."))
-        new{T}(obj)
+        new(obj)
     end
 end
 
@@ -68,7 +68,8 @@ function spa(X::Matrix{T}, k::Integer; nnls_alg::Tuple{Symbol, Symbol}=(:pivot, 
 end
 
 # calculate statistics for result
-function solve!(alg::SPA{T}, X, W, H) where T
+function solve!(alg::SPA, X, W, H)
+    T = eltype(W)
     if alg.obj == :mse
         objv = convert(T, 0.5) * sqL2dist(X, W*H)
     elseif alg.obj == :div

--- a/test/spa.jl
+++ b/test/spa.jl
@@ -29,4 +29,24 @@
         @test all(h .>= zero(T))
         @test sqL2dist(X, x) < eps(T)
     end
+
+    # SPA as a factorization algorithm: constructs without a type parameter
+    # and produces a Result whose element type follows the factors.
+    for T in (Float64, Float32)
+        Wg, Hg = NMF.separable_data(p, n, k)
+        X = T.(Wg * Hg)
+        W, H = NMF.spa(X, k)
+        ret = NMF.solve!(NMF.SPA(obj=:mse), X, W, H)
+        @test ret isa NMF.Result{T}
+        @test ret.converged
+    end
+    @test_throws ArgumentError NMF.SPA(obj=:nonsense)
+end
+
+@testset "algorithm type hierarchy" begin
+    for A in (NMF.MultUpdate{Float64}, NMF.ProjectedALS{Float64},
+              NMF.ALSPGrad{Float64}, NMF.CoordinateDescent{Float64},
+              NMF.GreedyCD{Float64}, NMF.SPA)
+        @test A <: NMF.AbstractNMFAlgorithm
+    end
 end


### PR DESCRIPTION
Give the algorithm-parameter structs (MultUpdate, ProjectedALS, ALSPGrad, CoordinateDescent, GreedyCD, SPA) a common supertype so solve!'s contract is expressible and callers can dispatch on the family.

SPA's only field is obj::Symbol and never used its type parameter, so it becomes a plain struct; solve!(::SPA, ...) derives the result element type from the factors.