### PR TITLE
Mark documented NMF.-prefixed bindings as public

### DIFF
--- a/src/NMF.jl
+++ b/src/NMF.jl
@@ -22,6 +22,15 @@ module NMF
 
     include("interf.jl")
 
+    # Supported, documented bindings that are reachable via the `NMF.` prefix
+    # rather than exported. `public` is a Julia 1.11+ keyword, so the eval keeps
+    # this file parseable on 1.10.
+    @static if VERSION >= v"1.11.0-DEV.469"
+        eval(Meta.parse("public AbstractNMFAlgorithm, Result, solve!, " *
+                        "randinit, nndsvd, spa, " *
+                        "MultUpdate, ProjectedALS, ALSPGrad, CoordinateDescent, GreedyCD, SPA"))
+    end
+
     using PrecompileTools: @compile_workload, @setup_workload
 
     let

--- a/test/interf.jl
+++ b/test/interf.jl
@@ -42,3 +42,13 @@
         end
     end
 end
+
+@static if VERSION >= v"1.11"
+    @testset "public bindings" begin
+        for name in (:AbstractNMFAlgorithm, :Result, :solve!, :randinit, :nndsvd,
+                     :spa, :MultUpdate, :ProjectedALS, :ALSPGrad,
+                     :CoordinateDescent, :GreedyCD, :SPA)
+            @test Base.ispublic(NMF, name)
+        end
+    end
+end


### PR DESCRIPTION
`Result`, `solve!`, `randinit`, `nndsvd`, `spa`, the algorithm-parameter types, and `AbstractNMFAlgorithm` are documented in the README and meant for use via the `NMF.` prefix, but only `nnmf` was exported. Declare them public so their supported status is machine-visible on Julia 1.11+.