### PR TITLE
Add a compact show for Result

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -48,6 +48,13 @@ end
 Base.:(==)(A::Result, B::Result) = A.W == B.W && A.H == B.H && A.niters == B.niters && A.converged == B.converged && A.objvalue == B.objvalue
 Base.hash(s::Result, h::UInt) = hash(s.objvalue, hash(s.converged, hash(s.niters, hash(s.H, hash(s.W, h + (0x09c9f08cfcba6de3 % UInt))))))
 
+function Base.show(io::IO, r::Result{T}) where T
+    p, k = size(r.W)
+    n = size(r.H, 2)
+    print(io, "Result{", T, "}(", p, '×', n, " ≈ W(", p, '×', k, ")·H(", k, '×', n, "), ",
+          "niters=", r.niters, ", converged=", r.converged, ", objvalue=", r.objvalue, ')')
+end
+
 
 # common algorithmic skeleton for iterative updating methods
 

--- a/test/interf.jl
+++ b/test/interf.jl
@@ -43,6 +43,18 @@
     end
 end
 
+@testset "Result show" begin
+    r = NMF.Result{Float64}(ones(5, 2), ones(2, 8), 42, true, 1.5)
+    str = sprint(show, r)
+    @test occursin("Result{Float64}", str)
+    @test occursin("5×8", str)        # X dimensions
+    @test occursin("niters=42", str)
+    @test occursin("converged=true", str)
+    @test occursin("objvalue=1.5", str)
+    # compact: does not dump the factor matrices
+    @test !occursin('\n', str)
+end
+
 @static if VERSION >= v"1.11"
     @testset "public bindings" begin
         for name in (:AbstractNMFAlgorithm, :Result, :solve!, :randinit, :nndsvd,


### PR DESCRIPTION
Previously displaying a `Result` dumped both full factor matrices. Print a one-line summary of the reconstruction shape and convergence metadata instead.