### PR TITLE
Move separable_data generator into the test suite

### DIFF
--- a/src/NMF.jl
+++ b/src/NMF.jl
@@ -2,7 +2,7 @@ module NMF
     using StatsBase: gkldiv, sqL2dist
     using Statistics: mean
     using Printf: @printf
-    using LinearAlgebra: Hermitian, cholesky!, diagind, dot, I, ldiv!, mul!, norm, rmul!
+    using LinearAlgebra: Hermitian, cholesky!, diagind, dot, ldiv!, mul!, norm, rmul!
     using NonNegLeastSquares: nonneg_lsq
     using Random: randperm, shuffle
     using RandomizedLinAlg: rsvd

--- a/src/spa.jl
+++ b/src/spa.jl
@@ -14,29 +14,6 @@ struct SPA <: AbstractNMFAlgorithm
     end
 end
 
-"""
-separable_data(m,n,k)
-Generate a (m x n) matrix X of nonnegative, separable data
-with nonnegative rank k. The rows of X correspond to
-observations and the columns of X correspond to features.
-The separability condition implies that the columns of H
-can be permuted to form a (k x k) diagonal block, and 
-the sum of the entries of each column of H is at most one. 
-Thus, the (scaled) columns of W appear in X.
-"""
-function separable_data(m, n, k)
-    W = rand(m, k)
-    
-    # impose separability
-    V = rand(k, n-k)
-    V ./= sum(V, dims=1)
-    H = [Matrix(I, k, k) V]
-    # permute columns of H
-    H = H[:, randperm(n)]
-    
-    return W, H
-end
-
 # initialization
 function spa(X::Matrix{T}, k::Integer; nnls_alg::Tuple{Symbol, Symbol}=(:pivot, :cache)) where T
 

--- a/test/spa.jl
+++ b/test/spa.jl
@@ -21,7 +21,7 @@
         #println("ϵ =",ϵ," while ||x .- X||= ",maximum(abs.(x .- X)))
 
         # Separability test
-        Wg, Hg = NMF.separable_data(p, n, k)
+        Wg, Hg = separable_data(p, n, k)
         X = Wg * Hg
         w, h = NMF.spa(X, k)
         x = w * h
@@ -33,7 +33,7 @@
     # SPA as a factorization algorithm: constructs without a type parameter
     # and produces a Result whose element type follows the factors.
     for T in (Float64, Float32)
-        Wg, Hg = NMF.separable_data(p, n, k)
+        Wg, Hg = separable_data(p, n, k)
         X = T.(Wg * Hg)
         W, H = NMF.spa(X, k)
         ret = NMF.solve!(NMF.SPA(obj=:mse), X, W, H)

--- a/test/testproblems.jl
+++ b/test/testproblems.jl
@@ -11,3 +11,20 @@ function laurberg6x3(α)
     X = W*H
     return X, Matrix(W), H
 end
+
+# Generate an (m × n) matrix X = W*H of nonnegative, separable data with
+# nonnegative rank k. The columns of H can be permuted to expose a (k × k)
+# identity block, so the (scaled) columns of W appear directly among the columns
+# of X — the separability condition the SPA algorithm relies on.
+function separable_data(m, n, k)
+    W = rand(m, k)
+
+    # impose separability
+    V = rand(k, n-k)
+    V ./= sum(V, dims=1)
+    H = [Matrix(I, k, k) V]
+    # permute columns of H
+    H = H[:, randperm(n)]
+
+    return W, H
+end


### PR DESCRIPTION
`separable_data` builds synthetic separable matrices used only to exercise
the SPA algorithm in tests; it was never part of the public API. Relocate
it to test/testproblems.jl and drop the now-unused LinearAlgebra.I import.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
