### PR TITLE
Loosen spa to accept any AbstractMatrix

### DIFF
--- a/src/spa.jl
+++ b/src/spa.jl
@@ -15,7 +15,7 @@ struct SPA <: AbstractNMFAlgorithm
 end
 
 # initialization
-function spa(X::Matrix{T}, k::Integer; nnls_alg::Tuple{Symbol, Symbol}=(:pivot, :cache)) where T
+function spa(X::AbstractMatrix{T}, k::Integer; nnls_alg::Tuple{Symbol, Symbol}=(:pivot, :cache)) where T
 
     # Normalize data so that columns of X sum to one
     R = X ./ sum(X, dims=1)

--- a/test/interf.jl
+++ b/test/interf.jl
@@ -1,12 +1,10 @@
 @testset "interf" begin
-    p = 5
-    n = 8
-    k = 3
+    Xg, Wg0, Hg0 = separable6x3()
+    p, k = size(Wg0)
+    n = size(Hg0, 2)
 
     for T in (Float64, Float32)
-        Wg = max.(rand(T, p, k) .- T(0.3), zero(T))
-        Hg = max.(rand(T, k, n) .- T(0.3), zero(T))
-        X = Wg * Hg
+        X = T.(Xg)
 
         for alg in (:multmse, :multdiv, :projals, :alspgrad, :cd, :greedycd)
             for init in (:random, :nndsvd, :nndsvda, :nndsvdar, :spa)
@@ -27,9 +25,10 @@
         # spa test
         ret = NMF.nnmf(X, k, alg=:spa, init=:spa)
 
-        # update_H test
-        W = max.(rand(T, p, k) .- T(0.3), zero(T))
-        H = max.(rand(T, k, n) .- T(0.3), zero(T))
+        # update_H test: with update_H=false, H is held fixed and only W moves,
+        # so start from a deliberately non-optimal W.
+        W = fill(T(1), p, k)
+        H = T.(Hg0)
         for alg in (:multmse, :multdiv, :projals, :alspgrad, :cd, :greedycd)
             ret = NMF.nnmf(X, k, alg=alg, init=:custom, W0=copy(W), H0=copy(H), update_H=false)
             @test all(H .== ret.H)

--- a/test/spa.jl
+++ b/test/spa.jl
@@ -40,6 +40,18 @@
         @test ret isa NMF.Result{T}
         @test ret.converged
     end
+    # Accepts any AbstractMatrix, not just a dense Matrix (e.g. a view).
+    let T = Float64
+        Wg, Hg = separable_data(p, n, k)
+        Xfull = T.(Wg * Hg)
+        Xpad = hcat(Xfull, ones(T, p))
+        Xview = view(Xpad, :, 1:n)
+        @test Xview isa SubArray
+        w, h = NMF.spa(Xview, k)
+        wf, hf = NMF.spa(Xfull, k)
+        @test w == wf
+        @test h == hf
+    end
     @test_throws ArgumentError NMF.SPA(obj=:nonsense)
 end
 

--- a/test/testproblems.jl
+++ b/test/testproblems.jl
@@ -12,6 +12,26 @@ function laurberg6x3(α)
     return X, Matrix(W), H
 end
 
+# An explicit, well-conditioned separable problem of nonnegative rank 3.
+# The first three columns of H form an identity block, so X[:, 1:3] == W
+# exactly; SPA must recover those columns, and the remaining columns are
+# strictly interior convex combinations. Deterministic, so tests built on it
+# do not depend on the RNG stream (which is not stable across Julia versions).
+function separable6x3()
+    W = [1 0 0
+         0 1 0
+         0 0 1
+         2 1 0
+         0 1 2
+         1 0 1]
+    V = [5 2 1
+         3 5 4
+         2 3 5] .// 10        # columns sum to 1
+    H = [Matrix(1//1 * I, 3, 3) V]
+    X = W * H
+    return float.(X), float.(W), float.(H)
+end
+
 # Generate an (m × n) matrix X = W*H of nonnegative, separable data with
 # nonnegative rank k. The columns of H can be permuted to expose a (k × k)
 # identity block, so the (scaled) columns of W appear directly among the columns


### PR DESCRIPTION
`spa` was the only entry point restricted to a concrete Matrix, unlike
`nnmf`. Accepting `AbstractMatrix` admits views, adjoints, OffsetArrays,
and GPU arrays.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
