### PR TITLE
Coerce Result constructor arguments

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -36,13 +36,16 @@ struct Result{T}
     converged::Bool
     objvalue::T
 
-    function Result{T}(W::Matrix{T}, H::Matrix{T}, niters::Int, converged::Bool, objv) where T
+    function Result{T}(W, H, niters, converged, objv) where T
         if size(W, 2) != size(H, 1)
             throw(DimensionMismatch("Inner dimensions of W and H mismatch."))
         end
         new{T}(W, H, niters, converged, objv)
     end
 end
+
+Result(W::AbstractMatrix, H::AbstractMatrix, niters, converged, objv) =
+    Result{promote_type(eltype(W), eltype(H))}(W, H, niters, converged, objv)
 
 
 Base.:(==)(A::Result, B::Result) = A.W == B.W && A.H == B.H && A.niters == B.niters && A.converged == B.converged && A.objvalue == B.objvalue

--- a/test/interf.jl
+++ b/test/interf.jl
@@ -42,6 +42,25 @@
     end
 end
 
+@testset "Result construction" begin
+    W = ones(5, 2); H = ones(2, 8)
+    ref = NMF.Result{Float64}(W, H, 42, true, 1.5)
+
+    # The inner constructor coerces non-Matrix and differently-typed arguments
+    # into the declared fields.
+    @test NMF.Result{Float64}(view(W, :, :), H, 42, true, 1.5) == ref
+    @test NMF.Result{Float64}(Int.(W), Int.(H), 42, true, 1.5) == ref
+    @test NMF.Result{Float64}(W, H, 42, true, 3//2) == ref
+
+    # The outer constructor infers T from the factor element types.
+    r = NMF.Result(W, H, 42, true, 1.5)
+    @test r isa NMF.Result{Float64}
+    @test r == ref
+    @test NMF.Result(Float32.(W), Float32.(H), 42, true, 1.5f0) isa NMF.Result{Float32}
+
+    @test_throws DimensionMismatch NMF.Result{Float64}(W, ones(3, 8), 42, true, 1.5)
+end
+
 @testset "Result show" begin
     r = NMF.Result{Float64}(ones(5, 2), ones(2, 8), 42, true, 1.5)
     str = sprint(show, r)


### PR DESCRIPTION
The inner Result{T} constructor constrained its W/H arguments to
Matrix{T}, blocking the conversion the field declarations would
otherwise perform (e.g. a view or integer matrix). Drop the
constraints and let `new` coerce. Add an outer constructor that
infers T from the factor element types.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
