### PR TITLE
Honor spa's nnls_alg keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ The function supports the following keyword arguments:
     - ``variant``: the variant of the algorithm. Default is ``std``, meaning to use the standard version, which would generate a rather sparse ``W``. Other values are ``a`` and ``ar``, respectively corresponding to the variants: *NNDSVDa* and *NNDSVDar*. Particularly, ``ar`` is recommended for dense NMF.
 
 
-- **NMF.spa**(X, k)
+- **NMF.spa**(X, k[; nnls_alg=(:pivot, :cache)])
 
     Use the *Successive Projection Algorithm (SPA)* to initialize ``W`` and ``H``.
 
@@ -150,6 +150,10 @@ The function supports the following keyword arguments:
     ```julia
     W, H = NMF.spa(X, k)
     ```
+
+    - ``nnls_alg``: the ``(alg, variant)`` pair forwarded to
+      ``NonNegLeastSquares.nonneg_lsq`` when solving for ``H``. Default is
+      ``(:pivot, :cache)``.
 
 
 ## Factorization Algorithms

--- a/src/spa.jl
+++ b/src/spa.jl
@@ -38,7 +38,7 @@ function spa(X::AbstractMatrix{T}, k::Integer; nnls_alg::Tuple{Symbol, Symbol}=(
     W = X[:,ai]
     
     # Estimate H by non-negative least squares: minimize ||X - W*H||
-    H = nonneg_lsq(W, X, alg=:fnnls)
+    H = nonneg_lsq(W, X; alg=nnls_alg[1], variant=nnls_alg[2])
     projectnn!(H) 
 
     return W, H

--- a/test/spa.jl
+++ b/test/spa.jl
@@ -52,6 +52,16 @@
         @test w == wf
         @test h == hf
     end
+    # nnls_alg is forwarded to the underlying NNLS solver.
+    let T = Float64
+        Wg, Hg = separable_data(p, n, k)
+        X = T.(Wg * Hg)
+        wd, hd = NMF.spa(X, k)                                # default (:pivot, :cache)
+        wf, hf = NMF.spa(X, k; nnls_alg=(:fnnls, :none))      # a different exact solver
+        @test wd == wf                                        # anchor selection is independent of nnls_alg
+        @test hd ≈ hf
+        @test_throws ArgumentError NMF.spa(X, k; nnls_alg=(:bogus, :none))
+    end
     @test_throws ArgumentError NMF.SPA(obj=:nonsense)
 end
 


### PR DESCRIPTION
spa accepted an nnls_alg keyword but ignored it, always solving for H
with the :fnnls solver. Forward the (alg, variant) pair to nonneg_lsq
so the keyword's declared default and any caller override take effect.
Document it in the README.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
