### PR TITLE
Reject negative lambda in MultUpdate

### DIFF
--- a/src/multupd.jl
+++ b/src/multupd.jl
@@ -29,7 +29,8 @@ struct MultUpdate{T} <: AbstractNMFAlgorithm
         tol > 0 || throw(ArgumentError("tol must be positive."))
         lambda_w >= 0 || throw(ArgumentError("lambda_w must be non-negative."))
         lambda_h >= 0 || throw(ArgumentError("lambda_h must be non-negative."))
-        if lambda !== nothing && lambda >= 0
+        if lambda !== nothing
+            lambda >= 0 || throw(ArgumentError("lambda must be non-negative."))
             @warn "lambda is deprecated, use lambda_w and lambda_h instead."
             lambda_w = iszero(lambda_w) ? lambda : lambda_w
             lambda_h = iszero(lambda_h) ? lambda : lambda_h

--- a/test/multupd.jl
+++ b/test/multupd.jl
@@ -19,4 +19,14 @@
             end
         end
     end
+
+    @testset "deprecated lambda keyword" begin
+        # A non-negative lambda warns and forwards to lambda_w/lambda_h.
+        alg = @test_logs (:warn, r"lambda is deprecated") NMF.MultUpdate{Float64}(lambda=0.5)
+        @test alg.lambda_w == 0.5
+        @test alg.lambda_h == 0.5
+        # A negative lambda is rejected rather than silently dropped.
+        @test_throws ArgumentError NMF.MultUpdate{Float64}(lambda=-1.0)
+        @test_throws "lambda must be non-negative" NMF.MultUpdate{Float64}(lambda=-1.0)
+    end
 end


### PR DESCRIPTION
The deprecated `lambda` keyword previously guarded its forwarding with
`lambda !== nothing && lambda >= 0`, so a negative value was silently
dropped: no warning, no error, no effect. Throw an ArgumentError for
lambda < 0, matching the lambda_w/lambda_h non-negativity checks, while
keeping the deprecation warning and forwarding for non-negative values.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
