### PR TITLE
Validate maxiter and tol in remaining algorithm constructors

### DIFF
--- a/src/alspgrad.jl
+++ b/src/alspgrad.jl
@@ -363,6 +363,8 @@ struct ALSPGrad{T} <: AbstractNMFAlgorithm
                           tolg::Real=eps(T)^(1/4),
                           update_H::Bool=true,
                           verbose::Bool=false) where T
+        maxiter > 1 || throw(ArgumentError("maxiter must be greater than 1."))
+        tol > 0 || throw(ArgumentError("tol must be positive."))
         new{T}(maxiter,
                maxsubiter,
                tol,

--- a/src/coorddesc.jl
+++ b/src/coorddesc.jl
@@ -41,6 +41,8 @@ struct CoordinateDescent{T} <: AbstractNMFAlgorithm
                               regularization=:both,
                               l₁ratio::Real=zero(T),
                               shuffle::Bool=false) where T
+        maxiter > 1 || throw(ArgumentError("maxiter must be greater than 1."))
+        tol > 0 || throw(ArgumentError("tol must be positive."))
         new{T}(maxiter, verbose, tol, update_H, α, l₁ratio, regularization, shuffle)
     end
 end

--- a/src/projals.jl
+++ b/src/projals.jl
@@ -27,6 +27,8 @@ struct ProjectedALS{T} <: AbstractNMFAlgorithm
                               lambda_w::Real=cbrt(eps(T)),
                               lambda_h::Real=cbrt(eps(T))) where T
 
+        maxiter > 1 || throw(ArgumentError("maxiter must be greater than 1."))
+        tol > 0 || throw(ArgumentError("tol must be positive."))
         new{T}(maxiter, verbose, tol, update_H, lambda_w, lambda_h)
     end
 end

--- a/test/interf.jl
+++ b/test/interf.jl
@@ -82,3 +82,15 @@ end
         end
     end
 end
+
+@testset "constructor argument validation" begin
+    # Every iterative algorithm rejects a degenerate maxiter/tol rather than
+    # silently returning niters=0, converged=false.
+    for Alg in (NMF.MultUpdate, NMF.ProjectedALS, NMF.ALSPGrad,
+                NMF.CoordinateDescent, NMF.GreedyCD)
+        @test_throws ArgumentError Alg{Float64}(maxiter=1)
+        @test_throws "maxiter must be greater than 1" Alg{Float64}(maxiter=0)
+        @test_throws ArgumentError Alg{Float64}(tol=0.0)
+        @test_throws "tol must be positive" Alg{Float64}(tol=-1.0)
+    end
+end


### PR DESCRIPTION
ProjectedALS, ALSPGrad, and CoordinateDescent accepted any maxiter and
tol, so a degenerate value (e.g. maxiter=0) silently produced a result
with niters=0 and converged=false rather than failing. Add the same
`maxiter > 1` / `tol > 0` ArgumentError guards that MultUpdate and
GreedyCD already enforce, and test that every iterative algorithm rejects
the degenerate inputs.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
