### PR TITLE
Reject degenerate column sums in spa and stop_condition

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -123,7 +123,11 @@ function stop_condition(W::AbstractArray{T}, preW::AbstractArray, H::AbstractArr
             dev_h += (H[j,i] - preH[j,i])^2
             sum_h += (H[j,i] + preH[j,i])^2
         end
-        devmax = max(devmax, sqrt(max(dev_w/sum_w, dev_h/sum_h)))
+        # A column that is all-zero in both W and preW (a dead component) gives
+        # sum==0 and dev==0; its relative change is zero, so guard the 0/0.
+        rel_w = sum_w > 0 ? dev_w/sum_w : zero(T)
+        rel_h = sum_h > 0 ? dev_h/sum_h : zero(T)
+        devmax = max(devmax, sqrt(max(rel_w, rel_h)))
         if sqrt(dev_w) > eps*sqrt(sum_w) || sqrt(dev_h) > eps*sqrt(sum_h)
             return false, devmax
         end

--- a/src/spa.jl
+++ b/src/spa.jl
@@ -17,8 +17,13 @@ end
 # initialization
 function spa(X::AbstractMatrix{T}, k::Integer; nnls_alg::Tuple{Symbol, Symbol}=(:pivot, :cache)) where T
 
-    # Normalize data so that columns of X sum to one
-    R = X ./ sum(X, dims=1)
+    # Normalize data so that columns of X sum to one. An all-zero column has no
+    # well-defined normalization (0/0), so reject it rather than propagate NaNs
+    # into the anchor-selection argmax.
+    colsums = sum(X, dims=1)
+    zerocols = findall(iszero, vec(colsums))
+    isempty(zerocols) || throw(ArgumentError("spa requires every column of X to have a nonzero sum; column(s) $zerocols sum to zero."))
+    R = X ./ colsums
 
     # W = R[:,ai], where ai are the "anchor indices"
     # (ai forms the convex hull of columns in R)

--- a/test/spa.jl
+++ b/test/spa.jl
@@ -63,6 +63,16 @@
         @test_throws ArgumentError NMF.spa(X, k; nnls_alg=(:bogus, :none))
     end
     @test_throws ArgumentError NMF.SPA(obj=:nonsense)
+
+    # An all-zero column has no well-defined normalization; spa must reject it
+    # rather than feed NaNs into anchor selection.
+    let T = Float64
+        Wg, Hg = separable_data(p, n, k)
+        X = T.(Wg * Hg)
+        X[:, 3] .= 0
+        @test_throws ArgumentError NMF.spa(X, k)
+        @test_throws "sum to zero" NMF.spa(X, k)
+    end
 end
 
 @testset "algorithm type hierarchy" begin

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -67,4 +67,17 @@
     Xnmf1 = deepcopy(Xnmf)
     @test Xnmf == Xnmf1
     @test hash(Xnmf) == hash(Xnmf1)
+
+    ## stop_condition
+
+    # A dead component (a column that is all-zero in both W and preW) gives a
+    # 0/0 relative change; it must be treated as zero, not poison devmax to NaN.
+    W = [1.0 0.0; 2.0 0.0]
+    preW = [1.0 0.0; 2.0 0.0]
+    H = [1.0 3.0; 0.0 0.0]
+    preH = [1.0 3.0; 0.0 0.0]
+    converged, devmax = NMF.stop_condition(W, preW, H, preH, 1e-6)
+    @test converged
+    @test isfinite(devmax)
+    @test devmax == 0.0
 end


### PR DESCRIPTION
spa normalizes X by column sums; an all-zero column has no defined
normalization (0/0) and its NaNs would win anchor selection, so reject
it with an ArgumentError naming the offending column(s).

In stop_condition a component that is all-zero in both W and preW gives
a 0/0 relative change. Its change is genuinely zero, so guard the ratio
rather than let NaN poison the reported devmax. The convergence test
itself was already unaffected.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
