### PR TITLE
Route verbose progress output through a caller-supplied io

### DIFF
--- a/src/alspgrad.jl
+++ b/src/alspgrad.jl
@@ -66,7 +66,8 @@ function set_w!(s::ALSGradUpdH_State, X, W)
     mul!(s.WtX, Wt, X)
 end
 
-function alspgrad_updateh!(X,
+function alspgrad_updateh!(io::IO,
+                           X,
                            W::VecOrMat{T},
                            H::VecOrMat{T};
                            maxiter::Int = 1000,
@@ -78,12 +79,13 @@ function alspgrad_updateh!(X,
 
     s = ALSGradUpdH_State(X, W, H)
     set_w!(s, X, W)
-    _alspgrad_updateh!(X, W, H, s,
+    _alspgrad_updateh!(io, X, W, H, s,
                        maxiter, traceiter, tolg,
                        beta, sigma, verbose)
 end
 
-function _alspgrad_updateh!(X,                      # size (p, n)
+function _alspgrad_updateh!(io::IO,                 # sink for verbose output
+                            X,                      # size (p, n)
                             W::VecOrMat,            # size (p, k)
                             H::VecOrMat,            # size (k, n)
                             s::ALSGradUpdH_State,   # state to hold temporary quantities
@@ -105,11 +107,11 @@ function _alspgrad_updateh!(X,                      # size (p, n)
 
     # banner
     if verbose
-        @printf("%5s    %12s    %12s    %12s    %8s    %12s\n",
+        @printf(io, "%5s    %12s    %12s    %12s    %8s    %12s\n",
             "Iter", "objv", "objv.change", "1st-ord", "alpha", "back-tracks")
         WH = W * H
         objv = convert(T, 0.5) * sqL2dist(X, WH)
-        @printf("%5d    %12.5e\n", 0, objv)
+        @printf(io, "%5d    %12.5e\n", 0, objv)
     end
 
     # main loop
@@ -183,7 +185,7 @@ function _alspgrad_updateh!(X,                      # size (p, n)
             mul!(WH, W, H)
             preobjv = objv
             objv = convert(T, 0.5) * sqL2dist(X, WH)
-            @printf("%5d    %12.5e    %12.5e    %12.5e    %8.4f    %12d\n",
+            @printf(io, "%5d    %12.5e    %12.5e    %12.5e    %8.4f    %12d\n",
                 t, objv, objv - preobjv, pgnrm, α, it)
         end
     end
@@ -222,7 +224,8 @@ function set_h!(s::ALSGradUpdW_State, X, H)
 end
 
 
-function alspgrad_updatew!(X,
+function alspgrad_updatew!(io::IO,
+                           X,
                            W::VecOrMat{T},
                            H::VecOrMat{T};
                            maxiter::Int = 1000,
@@ -234,12 +237,13 @@ function alspgrad_updatew!(X,
 
     s = ALSGradUpdW_State(X, W, H)
     set_h!(s, X, H)
-    _alspgrad_updatew!(X, W, H, s,
+    _alspgrad_updatew!(io, X, W, H, s,
                        maxiter, traceiter, tolg,
                        beta, sigma, verbose)
 end
 
-function _alspgrad_updatew!(X,                      # size (p, n)
+function _alspgrad_updatew!(io::IO,                 # sink for verbose output
+                            X,                      # size (p, n)
                             W::VecOrMat,            # size (p, k)
                             H::VecOrMat,            # size (k, n)
                             s::ALSGradUpdW_State,   # state to hold temporary quantities
@@ -261,11 +265,11 @@ function _alspgrad_updatew!(X,                      # size (p, n)
 
     # banner
     if verbose
-        @printf("%5s    %12s    %12s    %12s    %8s    %12s\n",
+        @printf(io, "%5s    %12s    %12s    %12s    %8s    %12s\n",
             "Iter", "objv", "objv.change", "1st-ord", "alpha", "back-tracks")
         WH = W * H
         objv = convert(T, 0.5) * sqL2dist(X, WH)
-        @printf("%5d    %12.5e\n", 0, objv)
+        @printf(io, "%5d    %12.5e\n", 0, objv)
     end
 
     # main loop
@@ -339,7 +343,7 @@ function _alspgrad_updatew!(X,                      # size (p, n)
             mul!(WH, W, H)
             preobjv = objv
             objv = convert(T, 0.5) * sqL2dist(X, WH)
-            @printf("%5d    %12.5e    %12.5e    %12.5e    %8.4f    %12d\n",
+            @printf(io, "%5d    %12.5e    %12.5e    %12.5e    %8.4f    %12d\n",
                 t, objv, objv - preobjv, pgnrm, α, it)
         end
     end
@@ -380,8 +384,8 @@ mutable struct ALSPGradUpd{T} <: NMFUpdater{T}
     tolg::T
 end
 
-solve!(alg::ALSPGrad, X, W, H) =
-    nmf_skeleton!(ALSPGradUpd(alg.update_H, alg.maxsubiter, alg.tolg),
+solve!(alg::ALSPGrad, X, W, H; io::IO=stdout) =
+    nmf_skeleton!(io, ALSPGradUpd(alg.update_H, alg.maxsubiter, alg.tolg),
                   X, W, H, alg.maxiter, alg.verbose, alg.tol)
 
 
@@ -405,7 +409,7 @@ function update_wh!(upd::ALSPGradUpd, s::ALSPGradUpd_State, X, W, H)
     # update H
     if upd.update_H
         set_w!(s.uhstate, X, W)
-        iterH = _alspgrad_updateh!(X, W, H, s.uhstate,
+        iterH = _alspgrad_updateh!(stdout, X, W, H, s.uhstate,
             upd.maxsubiter, 20, upd.tolg, convert(T, 0.2), convert(T, 0.01), false)[2]
 
         if iterH == 1
@@ -415,7 +419,7 @@ function update_wh!(upd::ALSPGradUpd, s::ALSPGradUpd_State, X, W, H)
 
     # update W
     set_h!(s.uwstate, X, H)
-    iterW = _alspgrad_updatew!(X, W, H, s.uwstate,
+    iterW = _alspgrad_updatew!(stdout, X, W, H, s.uwstate,
         upd.maxsubiter, 20, upd.tolg, convert(T, 0.2), convert(T, 0.01), false)[2]
 
     if iterW == 1

--- a/src/common.jl
+++ b/src/common.jl
@@ -63,7 +63,7 @@ end
 
 abstract type NMFUpdater{T} end
 
-function nmf_skeleton!(updater::NMFUpdater{T},
+function nmf_skeleton!(io::IO, updater::NMFUpdater{T},
                        X, W::Matrix{T}, H::Matrix{T},
                        maxiter::Int, verbose::Bool, tol) where T
     objv = convert(T, NaN)
@@ -75,8 +75,8 @@ function nmf_skeleton!(updater::NMFUpdater{T},
     if verbose
         start = time()
         objv = evaluate_objv(updater, state, X, W, H)
-        @printf("%-5s    %-13s    %-13s    %-13s    %-13s\n", "Iter", "Elapsed time", "objv", "objv.change", "(W & H).relchange")
-        @printf("%5d    %13.6e    %13.6e\n", 0, 0.0, objv)
+        @printf(io, "%-5s    %-13s    %-13s    %-13s    %-13s\n", "Iter", "Elapsed time", "objv", "objv.change", "(W & H).relchange")
+        @printf(io, "%5d    %13.6e    %13.6e\n", 0, 0.0, objv)
     end
 
     # main loop
@@ -98,7 +98,7 @@ function nmf_skeleton!(updater::NMFUpdater{T},
             elapsed = time() - start
             preobjv = objv
             objv = evaluate_objv(updater, state, X, W, H)
-            @printf("%5d    %13.6e    %13.6e    %13.6e    %13.6e\n",
+            @printf(io, "%5d    %13.6e    %13.6e    %13.6e    %13.6e\n",
                 t, elapsed, objv, objv - preobjv, dev)
         end
     end

--- a/src/coorddesc.jl
+++ b/src/coorddesc.jl
@@ -48,8 +48,8 @@ struct CoordinateDescent{T} <: AbstractNMFAlgorithm
 end
 
 
-solve!(alg::CoordinateDescent{T}, X, W, H) where {T} =
-    nmf_skeleton!(CoordinateDescentUpd{T}(alg.α, alg.l₁ratio, alg.regularization, alg.shuffle, alg.update_H),
+solve!(alg::CoordinateDescent{T}, X, W, H; io::IO=stdout) where {T} =
+    nmf_skeleton!(io, CoordinateDescentUpd{T}(alg.α, alg.l₁ratio, alg.regularization, alg.shuffle, alg.update_H),
                   X, W, H, alg.maxiter, alg.verbose, alg.tol)
 
 

--- a/src/greedycd.jl
+++ b/src/greedycd.jl
@@ -30,8 +30,8 @@ struct GreedyCD{T} <: AbstractNMFAlgorithm
     end
 end
 
-solve!(alg::GreedyCD{T}, X, W, H) where T = 
-    nmf_skeleton!(GreedyCDUpd{T}(alg.update_H, alg.lambda_w, alg.lambda_h), X, W, H, alg.maxiter, alg.verbose, alg.tol)
+solve!(alg::GreedyCD{T}, X, W, H; io::IO=stdout) where T =
+    nmf_skeleton!(io, GreedyCDUpd{T}(alg.update_H, alg.lambda_w, alg.lambda_h), X, W, H, alg.maxiter, alg.verbose, alg.tol)
 
 
 struct GreedyCDUpd{T} <: NMFUpdater{T}

--- a/src/interf.jl
+++ b/src/interf.jl
@@ -10,7 +10,8 @@ function nnmf(X::AbstractMatrix{T}, k::Integer;
               W0::Union{AbstractMatrix{T}, Nothing}=nothing,
               H0::Union{AbstractMatrix{T}, Nothing}=nothing,
               update_H::Bool=true,
-              verbose::Bool=false) where T
+              verbose::Bool=false,
+              io::IO=stdout) where T
 
     eltype(X) <: Number && all(t -> t >= zero(T), X) || throw(ArgumentError("The elements of X must be non-negative."))
 
@@ -59,22 +60,22 @@ function nnmf(X::AbstractMatrix{T}, k::Integer;
 
     # choose algorithm
     if alg == :projals
-        ret = solve_replicates!(ProjectedALS{T}(maxiter=maxiter, tol=tol, verbose=verbose, update_H=update_H), X, W, H; replicates, initH)
+        ret = solve_replicates!(ProjectedALS{T}(maxiter=maxiter, tol=tol, verbose=verbose, update_H=update_H), X, W, H; replicates, initH, io)
     elseif alg == :alspgrad
-        ret = solve_replicates!(ALSPGrad{T}(maxiter=maxiter, tol=tol, verbose=verbose, update_H=update_H), X, W, H; replicates, initH)
+        ret = solve_replicates!(ALSPGrad{T}(maxiter=maxiter, tol=tol, verbose=verbose, update_H=update_H), X, W, H; replicates, initH, io)
     elseif alg == :multmse
-        ret = solve_replicates!(MultUpdate{T}(obj=:mse, maxiter=maxiter, tol=tol, verbose=verbose, update_H=update_H), X, W, H; replicates, initH)
+        ret = solve_replicates!(MultUpdate{T}(obj=:mse, maxiter=maxiter, tol=tol, verbose=verbose, update_H=update_H), X, W, H; replicates, initH, io)
     elseif alg == :multdiv
-        ret = solve_replicates!(MultUpdate{T}(obj=:div, maxiter=maxiter, tol=tol, verbose=verbose, update_H=update_H), X, W, H; replicates, initH)
+        ret = solve_replicates!(MultUpdate{T}(obj=:div, maxiter=maxiter, tol=tol, verbose=verbose, update_H=update_H), X, W, H; replicates, initH, io)
     elseif alg == :cd
-        ret = solve_replicates!(CoordinateDescent{T}(maxiter=maxiter, tol=tol, verbose=verbose, update_H=update_H), X, W, H; replicates, initH)
+        ret = solve_replicates!(CoordinateDescent{T}(maxiter=maxiter, tol=tol, verbose=verbose, update_H=update_H), X, W, H; replicates, initH, io)
     elseif alg == :greedycd
-        ret = solve_replicates!(GreedyCD{T}(maxiter=maxiter, tol=tol, verbose=verbose, update_H=update_H), X, W, H; replicates, initH)
+        ret = solve_replicates!(GreedyCD{T}(maxiter=maxiter, tol=tol, verbose=verbose, update_H=update_H), X, W, H; replicates, initH, io)
     elseif alg == :spa
         if init != :spa
             throw(ArgumentError("Invalid value for init, use :spa instead."))
         end
-        ret = solve_replicates!(SPA(obj=:mse), X, W, H; replicates, initH)
+        ret = solve_replicates!(SPA(obj=:mse), X, W, H; replicates, initH, io)
     else
         throw(ArgumentError("Invalid algorithm."))
     end
@@ -82,15 +83,15 @@ function nnmf(X::AbstractMatrix{T}, k::Integer;
     return ret
 end
 
-function solve_replicates!(alginst, X, W, H; replicates, initH)
-    ret = solve!(alginst, X, W, H)
+function solve_replicates!(alginst, X, W, H; replicates, initH, io::IO=stdout)
+    ret = solve!(alginst, X, W, H; io)
     k = size(W, 2)
 
     # replicates
     minobjv = ret.objvalue
     for _ in 2:replicates
         Wrand, Hrand = randinit(X, k; zeroh=!initH, normalize=true)
-        tmp = solve!(alginst, X, Wrand, Hrand)
+        tmp = solve!(alginst, X, Wrand, Hrand; io)
         if minobjv > tmp.objvalue
             ret = tmp
             minobjv = tmp.objvalue

--- a/src/multupd.jl
+++ b/src/multupd.jl
@@ -43,12 +43,12 @@ struct MultUpdate{T} <: AbstractNMFAlgorithm
     end
 end
 
-function solve!(alg::MultUpdate{T}, X, W, H) where T
+function solve!(alg::MultUpdate{T}, X, W, H; io::IO=stdout) where T
 
     if alg.obj == :mse
-        nmf_skeleton!(MultUpdMSE(alg.update_H, alg.lambda_w, alg.lambda_h, sqrt(eps(T))), X, W, H, alg.maxiter, alg.verbose, alg.tol)
+        nmf_skeleton!(io, MultUpdMSE(alg.update_H, alg.lambda_w, alg.lambda_h, sqrt(eps(T))), X, W, H, alg.maxiter, alg.verbose, alg.tol)
     else # alg == :div
-        nmf_skeleton!(MultUpdDiv(alg.update_H, alg.lambda_w, alg.lambda_h, sqrt(eps(T))), X, W, H, alg.maxiter, alg.verbose, alg.tol)
+        nmf_skeleton!(io, MultUpdDiv(alg.update_H, alg.lambda_w, alg.lambda_h, sqrt(eps(T))), X, W, H, alg.maxiter, alg.verbose, alg.tol)
     end
 end
 

--- a/src/projals.jl
+++ b/src/projals.jl
@@ -33,8 +33,8 @@ struct ProjectedALS{T} <: AbstractNMFAlgorithm
     end
 end
 
-solve!(alg::ProjectedALS, X, W, H) =
-    nmf_skeleton!(ProjectedALSUpd(alg.update_H, alg.lambda_w, alg.lambda_h),
+solve!(alg::ProjectedALS, X, W, H; io::IO=stdout) =
+    nmf_skeleton!(io, ProjectedALSUpd(alg.update_H, alg.lambda_w, alg.lambda_h),
                   X, W, H, alg.maxiter, alg.verbose, alg.tol)
 
 

--- a/src/spa.jl
+++ b/src/spa.jl
@@ -50,7 +50,7 @@ function spa(X::AbstractMatrix{T}, k::Integer; nnls_alg::Tuple{Symbol, Symbol}=(
 end
 
 # calculate statistics for result
-function solve!(alg::SPA, X, W, H)
+function solve!(alg::SPA, X, W, H; io::IO=stdout)
     T = eltype(W)
     if alg.obj == :mse
         objv = convert(T, 0.5) * sqL2dist(X, W*H)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,11 +1,11 @@
 # Numerical utilities to support implementation
 
-function printf_mat(x::AbstractMatrix)
+function printf_mat(io::IO, x::AbstractMatrix)
     @inbounds for i = 1:size(x,1)
         for j = 1:size(x,2)
-            @printf("%8.4f ", x[i,j])
+            @printf(io, "%8.4f ", x[i,j])
         end
-        println()
+        println(io)
     end
 end
 

--- a/test/alspgrad.jl
+++ b/test/alspgrad.jl
@@ -8,14 +8,14 @@
         # test update of H
 
         H = rand(T, size(Hg)...)
-        NMF.alspgrad_updateh!(X, Wg, H; maxiter=1000, tolg=eps(T))
+        NMF.alspgrad_updateh!(stdout, X, Wg, H; maxiter=1000, tolg=eps(T))
         @test all(H .>= zero(T))
         @test H ≈ Hg atol=eps(T)^(1/4)
 
         # test update of W
 
         W = rand(T, size(Wg)...)
-        NMF.alspgrad_updatew!(X, W, Hg; maxiter=1000, tolg=eps(T))
+        NMF.alspgrad_updatew!(stdout, X, W, Hg; maxiter=1000, tolg=eps(T))
         @test all(W .>= zero(T))
         @test W ≈ Wg atol=eps(T)^(1/4)
 

--- a/test/interf.jl
+++ b/test/interf.jl
@@ -35,11 +35,35 @@
             @test any(W .!= ret.W)
         end
 
-        # printing test
-        redirect_stdout(devnull) do
-            ret = NMF.nnmf(X, k, alg=:cd, init=:nndsvd, verbose=true)
-        end
+        # verbose progress is routed to the caller-supplied io, not stdout
+        buf = IOBuffer()
+        NMF.nnmf(X, k, alg=:cd, init=:nndsvd, verbose=true, io=buf)
+        out = String(take!(buf))
+        @test occursin("Iter", out)
+        @test occursin("objv", out)
+        # with verbose off, nothing is written to io
+        NMF.nnmf(X, k, alg=:cd, init=:nndsvd, verbose=false, io=buf)
+        @test isempty(take!(buf))
     end
+end
+
+@testset "verbose io redirection" begin
+    Random.seed!(1234)
+    k = 3
+    Wg = max.(rand(6, k) .- 0.3, 0.0)
+    Hg = max.(rand(k, 8) .- 0.3, 0.0)
+    X = Wg * Hg
+
+    # solve! accepts an io keyword and writes verbose output there
+    W, H = NMF.randinit(X, k)
+    buf = IOBuffer()
+    NMF.solve!(NMF.MultUpdate{Float64}(; maxiter=10, verbose=true), X, W, H; io=buf)
+    @test occursin("Iter", String(take!(buf)))
+
+    # the ALSPGrad sub-routine entry points take io as their first argument
+    W, H = NMF.randinit(X, k)
+    NMF.alspgrad_updateh!(buf, X, W, H; maxiter=20, verbose=true)
+    @test occursin("objv", String(take!(buf)))
 end
 
 @testset "Result construction" begin


### PR DESCRIPTION
The verbose progress reports printed by the iterative solvers went to the
process's stdout with no way to capture or redirect them. Add an
`io::IO = stdout` keyword to the public entry points (`nnmf` and every
`solve!` method) and thread it, positional-first per Base convention, into
the internal helpers (`nmf_skeleton!`, the ALSPGrad sub-routines and their
wrappers, `printf_mat`), so all `@printf`/`println` calls write to `io`.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
