### PR TITLE
Reject offset-axis inputs at the public boundaries

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,6 +17,7 @@ Aqua = "0.8"
 ExplicitImports = "1.15"
 LinearAlgebra = "1"
 NonNegLeastSquares = "0.2.0, 0.3.0, 0.4.0"
+OffsetArrays = "1"
 PrecompileTools = "1"
 Printf = "1"
 Random = "1"
@@ -28,7 +29,8 @@ julia = "1.10"
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
+OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "ExplicitImports", "Test"]
+test = ["Aqua", "ExplicitImports", "OffsetArrays", "Test"]

--- a/src/alspgrad.jl
+++ b/src/alspgrad.jl
@@ -384,9 +384,11 @@ mutable struct ALSPGradUpd{T} <: NMFUpdater{T}
     tolg::T
 end
 
-solve!(alg::ALSPGrad, X, W, H; io::IO=stdout, rng::AbstractRNG=default_rng()) =
+function solve!(alg::ALSPGrad, X, W, H; io::IO=stdout, rng::AbstractRNG=default_rng())
+    Base.require_one_based_indexing(X, W, H)
     nmf_skeleton!(io, ALSPGradUpd(alg.update_H, alg.maxsubiter, alg.tolg),
                   X, W, H, alg.maxiter, alg.verbose, alg.tol)
+end
 
 
 struct ALSPGradUpd_State{T}

--- a/src/coorddesc.jl
+++ b/src/coorddesc.jl
@@ -48,9 +48,11 @@ struct CoordinateDescent{T} <: AbstractNMFAlgorithm
 end
 
 
-solve!(alg::CoordinateDescent{T}, X, W, H; io::IO=stdout, rng::AbstractRNG=default_rng()) where {T} =
+function solve!(alg::CoordinateDescent{T}, X, W, H; io::IO=stdout, rng::AbstractRNG=default_rng()) where {T}
+    Base.require_one_based_indexing(X, W, H)
     nmf_skeleton!(io, CoordinateDescentUpd{T}(alg.α, alg.l₁ratio, alg.regularization, alg.shuffle, alg.update_H, rng),
                   X, W, H, alg.maxiter, alg.verbose, alg.tol)
+end
 
 
 struct CoordinateDescentUpd{T,R<:AbstractRNG} <: NMFUpdater{T}

--- a/src/greedycd.jl
+++ b/src/greedycd.jl
@@ -30,8 +30,10 @@ struct GreedyCD{T} <: AbstractNMFAlgorithm
     end
 end
 
-solve!(alg::GreedyCD{T}, X, W, H; io::IO=stdout, rng::AbstractRNG=default_rng()) where T =
+function solve!(alg::GreedyCD{T}, X, W, H; io::IO=stdout, rng::AbstractRNG=default_rng()) where T
+    Base.require_one_based_indexing(X, W, H)
     nmf_skeleton!(io, GreedyCDUpd{T}(alg.update_H, alg.lambda_w, alg.lambda_h), X, W, H, alg.maxiter, alg.verbose, alg.tol)
+end
 
 
 struct GreedyCDUpd{T} <: NMFUpdater{T}

--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -13,6 +13,7 @@ function randinit(nrows::Integer, ncols::Integer, k::Integer, T::DataType;
 end
 
 function randinit(X, k::Integer; normalize::Bool=false, zeroh::Bool=false, rng::AbstractRNG=default_rng())
+    Base.require_one_based_indexing(X)
     p, n = size(X)
     randinit(p, n, k, eltype(X); normalize, zeroh, rng)
 end
@@ -88,6 +89,7 @@ end
 function nndsvd(X, k::Integer; zeroh::Bool=false, variant::Symbol=:std, initdata=nothing,
                 rng::AbstractRNG=default_rng())
 
+    Base.require_one_based_indexing(X)
     p, n = size(X)
     T = eltype(X)
     ivar = variant == :std ? 0 :

--- a/src/interf.jl
+++ b/src/interf.jl
@@ -14,6 +14,11 @@ function nnmf(X::AbstractMatrix{T}, k::Integer;
               io::IO=stdout,
               rng::AbstractRNG=default_rng()) where T
 
+    # The factorization is built from dense linear algebra and returned as plain
+    # `Matrix`es, so offset axes cannot be honored; reject them rather than
+    # return a result whose axes silently disagree with the input.
+    Base.require_one_based_indexing(X)
+
     eltype(X) <: Number && all(t -> t >= zero(T), X) || throw(ArgumentError("The elements of X must be non-negative."))
 
     p, n = size(X)
@@ -27,6 +32,7 @@ function nnmf(X::AbstractMatrix{T}, k::Integer;
 
     if init == :custom
         W0 !== nothing && H0 !== nothing || throw(ArgumentError("To use :custom initialization, set W0 and H0."))
+        Base.require_one_based_indexing(W0, H0)
         eltype(W0) <: Number && all(t -> t >= zero(T), W0) || throw(ArgumentError("The elements of W0 must be non-negative."))
         p0, k0 = size(W0)
         p == p0 && k == k0 || throw(ArgumentError("Invalid size for W0."))

--- a/src/multupd.jl
+++ b/src/multupd.jl
@@ -45,6 +45,7 @@ end
 
 function solve!(alg::MultUpdate{T}, X, W, H; io::IO=stdout, rng::AbstractRNG=default_rng()) where T
 
+    Base.require_one_based_indexing(X, W, H)
     if alg.obj == :mse
         nmf_skeleton!(io, MultUpdMSE(alg.update_H, alg.lambda_w, alg.lambda_h, sqrt(eps(T))), X, W, H, alg.maxiter, alg.verbose, alg.tol)
     else # alg == :div

--- a/src/projals.jl
+++ b/src/projals.jl
@@ -33,9 +33,11 @@ struct ProjectedALS{T} <: AbstractNMFAlgorithm
     end
 end
 
-solve!(alg::ProjectedALS, X, W, H; io::IO=stdout, rng::AbstractRNG=default_rng()) =
+function solve!(alg::ProjectedALS, X, W, H; io::IO=stdout, rng::AbstractRNG=default_rng())
+    Base.require_one_based_indexing(X, W, H)
     nmf_skeleton!(io, ProjectedALSUpd(alg.update_H, alg.lambda_w, alg.lambda_h),
                   X, W, H, alg.maxiter, alg.verbose, alg.tol)
+end
 
 
 struct ProjectedALSUpd{T} <: NMFUpdater{T}

--- a/src/spa.jl
+++ b/src/spa.jl
@@ -17,6 +17,8 @@ end
 # initialization
 function spa(X::AbstractMatrix{T}, k::Integer; nnls_alg::Tuple{Symbol, Symbol}=(:pivot, :cache)) where T
 
+    Base.require_one_based_indexing(X)
+
     # Normalize data so that columns of X sum to one. An all-zero column has no
     # well-defined normalization (0/0), so reject it rather than propagate NaNs
     # into the anchor-selection argmax.
@@ -51,6 +53,7 @@ end
 
 # calculate statistics for result
 function solve!(alg::SPA, X, W, H; io::IO=stdout, rng::AbstractRNG=default_rng())
+    Base.require_one_based_indexing(X, W, H)
     T = eltype(W)
     if alg.obj == :mse
         objv = convert(T, 0.5) * sqL2dist(X, W*H)

--- a/test/genericaxes.jl
+++ b/test/genericaxes.jl
@@ -1,0 +1,44 @@
+# The factorizations are built from dense linear algebra and returned as plain
+# `Matrix`es, so offset axes cannot be honored. Every public entry point that
+# takes array data must reject offset input at the boundary rather than return a
+# result whose axes silently disagree with the input. Without the guards,
+# `nnmf` returns an all-NaN "converged" factorization and `nndsvd` a silently
+# wrong one.
+@testset "generic axes" begin
+    X = abs.(randn(MersenneTwister(1), 8, 6)) .+ 0.1
+    k = 3
+    msg = "offset arrays are not supported"
+
+    @testset "offset axes are rejected" begin
+        # both data axes shifted, and each one alone
+        for offset in ((-2, -2), (-2, 0), (0, -2))
+            Xo = OffsetArray(X, offset...)
+            for alg in (:greedycd, :cd, :multmse, :multdiv, :projals, :alspgrad)
+                @test_throws msg nnmf(Xo, k; alg)
+            end
+            @test_throws msg nnmf(Xo, k; alg=:spa, init=:spa)
+            @test_throws msg NMF.randinit(Xo, k)
+            @test_throws msg NMF.nndsvd(Xo, k)
+            @test_throws msg NMF.spa(Xo, k)
+        end
+
+        # :custom initialization must reject offset W0/H0 too
+        Wo = OffsetArray(rand(8, k), -2, 0)
+        Ho = OffsetArray(rand(k, 6), 0, -2)
+        @test_throws msg nnmf(X, k; init=:custom, W0=Wo, H0=rand(k, 6))
+        @test_throws msg nnmf(X, k; init=:custom, W0=rand(8, k), H0=Ho)
+    end
+
+    # solve! is public and guards independently of nnmf, on each of X, W, and H
+    @testset "solve! rejects offset axes" begin
+        W, H = NMF.randinit(X, k; normalize=true)
+        Wo, Ho, Xo = OffsetArray(copy(W), -1, 0), OffsetArray(copy(H), 0, -1), OffsetArray(X, -1, -1)
+        for alg in (NMF.GreedyCD{Float64}(), NMF.CoordinateDescent{Float64}(),
+                    NMF.MultUpdate{Float64}(), NMF.ProjectedALS{Float64}(),
+                    NMF.ALSPGrad{Float64}(), NMF.SPA())
+            @test_throws msg NMF.solve!(alg, Xo, W, H)
+            @test_throws msg NMF.solve!(alg, X, Wo, H)
+            @test_throws msg NMF.solve!(alg, X, W, Ho)
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ using LinearAlgebra
 using StatsBase
 using Aqua
 using ExplicitImports
+using OffsetArrays
 
 include("testproblems.jl")
 
@@ -30,6 +31,7 @@ println("Running tests:")
                               all_explicit_imports_are_public   = VERSION >= v"1.11",
                               all_qualified_accesses_are_public = VERSION >= v"1.11")
     end
+    include("genericaxes.jl")
     for t in tests
         tp = "$t.jl"
         include(tp)


### PR DESCRIPTION
NMF builds its factorizations from dense linear algebra and returns
plain `Matrix`es, so offset axes cannot be carried through. Passing an
offset array previously produced a silently wrong result: `nnmf`
returned an all-NaN factorization reported as converged, and `nndsvd`
returned a finite but incorrect one.

Guard every public entry point that takes array data
(`nnmf`, `randinit`, `nndsvd`, `spa`, and the `solve!` methods) with
`Base.require_one_based_indexing`, so offset input fails immediately with
a clear message instead of propagating into the result.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
