### PR TITLE
Raise test coverage to 99.6%; drop two dead helpers

### DIFF
--- a/src/alspgrad.jl
+++ b/src/alspgrad.jl
@@ -18,24 +18,6 @@ function projgradnorm(g, x)
     return sqrt(v)
 end
 
-# Determine the maximum step size we can take without
-# all elements of A becoming zero
-# The new value of A would be A = A - α*G
-function maxstep(G, A)
-    T = typeof(one(eltype(A)) / one(eltype(G)))
-    αmax = zero(T)
-    for i = 1:length(G)
-        g = G[i]
-        if g >= 0
-            αmax = max(αmax, A[i] / g)
-        else
-            αmax = convert(T, Inf)
-            break
-        end
-    end
-    return αmax
-end
-
 ## sub-routines for updating H
 
 struct ALSGradUpdH_State{T}

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,14 +1,5 @@
 # Numerical utilities to support implementation
 
-function printf_mat(io::IO, x::AbstractMatrix)
-    @inbounds for i = 1:size(x,1)
-        for j = 1:size(x,2)
-            @printf(io, "%8.4f ", x[i,j])
-        end
-        println(io)
-    end
-end
-
 function adddiag!(A::Matrix, a::Number)
     m, n = size(A)
     m == n || error("A must be square.")

--- a/test/initialization.jl
+++ b/test/initialization.jl
@@ -50,6 +50,5 @@
 
         W, H = NMF.nndsvd(X, 5; variant=:ar)
         @test all(W .> zero(T))
-        # NMF.printf_mat(W)
     end
 end

--- a/test/interf.jl
+++ b/test/interf.jl
@@ -64,6 +64,11 @@ end
     W, H = NMF.randinit(X, k)
     NMF.alspgrad_updateh!(buf, X, W, H; maxiter=20, verbose=true)
     @test occursin("objv", String(take!(buf)))
+
+    # the W-update sub-routine writes its verbose trace to the same io
+    W, H = NMF.randinit(X, k)
+    NMF.alspgrad_updatew!(buf, X, W, H; maxiter=20, verbose=true)
+    @test occursin("objv", String(take!(buf)))
 end
 
 @testset "rng reproducibility" begin
@@ -145,6 +150,30 @@ end
             @test Base.ispublic(NMF, name)
         end
     end
+end
+
+@testset "nnmf argument validation" begin
+    Xg, Wg0, Hg0 = separable6x3()
+    p, k = size(Wg0)
+    n = size(Hg0, 2)
+    X = Float64.(Xg)
+
+    # Holding H fixed while starting from a non-custom initialization warns that
+    # the supplied factorization target is being ignored for H.
+    @test_logs (:warn, "Only W will be updated.") NMF.nnmf(X, k; alg=:multmse, init=:random, update_H=false, maxiter=10)
+
+    # Unknown init/alg symbols are rejected with an explanatory message.
+    @test_throws "Invalid value for init." NMF.nnmf(X, k; init=:bogus)
+    @test_throws "Invalid algorithm." NMF.nnmf(X, k; alg=:bogus, init=:random)
+
+    # The :spa algorithm is only valid with :spa initialization.
+    @test_throws "use :spa instead" NMF.nnmf(X, k; alg=:spa, init=:random)
+
+    # nmf_checksize rejects factor dimensions that are mutually inconsistent.
+    W = rand(p, k)
+    Hbad = rand(k + 1, n)
+    @test_throws DimensionMismatch NMF.solve!(NMF.MultUpdate{Float64}(), X, W, Hbad)
+    @test_throws "Dimensions of X, W, and H are inconsistent." NMF.solve!(NMF.MultUpdate{Float64}(), X, W, Hbad)
 end
 
 @testset "constructor argument validation" begin

--- a/test/spa.jl
+++ b/test/spa.jl
@@ -39,6 +39,12 @@
         ret = NMF.solve!(NMF.SPA(obj=:mse), X, W, H)
         @test ret isa NMF.Result{T}
         @test ret.converged
+
+        # obj=:div scores the same factorization by generalized KL divergence.
+        retdiv = NMF.solve!(NMF.SPA(obj=:div), X, W, H)
+        @test retdiv isa NMF.Result{T}
+        @test retdiv.converged
+        @test retdiv.objvalue ≈ NMF.gkldiv(X, W * H)
     end
     # Accepts any AbstractMatrix, not just a dense Matrix (e.g. a view).
     let T = Float64


### PR DESCRIPTION
Remove `maxstep` (orphaned when #47 reimplemented ALS via projected
gradient descent) and `printf_mat` (never called from src). Add tests
for the nnmf argument-validation paths, nmf_checksize's dimension
check, SPA's obj=:div scoring, and the ALSPGrad W-update verbose trace.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
