### PR TITLE
Add docstrings for the public API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 Aqua = "0.8"
+Documenter = "1"
 ExplicitImports = "1.15"
 LinearAlgebra = "1"
 NonNegLeastSquares = "0.2.0, 0.3.0, 0.4.0"
@@ -28,9 +29,10 @@ julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "ExplicitImports", "OffsetArrays", "Test"]
+test = ["Aqua", "Documenter", "ExplicitImports", "OffsetArrays", "Test"]

--- a/src/NMF.jl
+++ b/src/NMF.jl
@@ -1,3 +1,14 @@
+"""
+NMF.jl provides algorithms and initializations for non-negative matrix
+factorization: approximating a non-negative matrix `X` of size `p×n` by a
+product `W*H`, where `W` is `p×k`, `H` is `k×n`, both are non-negative, and `k`
+is a chosen rank.
+
+The high-level entry point is [`nnmf`](@ref), which performs initialization and
+optimization in a single call. For finer control, initialize `W` and `H` with
+[`NMF.randinit`](@ref), [`NMF.nndsvd`](@ref), or [`NMF.spa`](@ref) and then run
+an algorithm in place with [`NMF.solve!`](@ref).
+"""
 module NMF
     using StatsBase: gkldiv, sqL2dist
     using Statistics: mean

--- a/src/alspgrad.jl
+++ b/src/alspgrad.jl
@@ -335,6 +335,36 @@ end
 
 ## main algorithm
 
+"""
+    ALSPGrad{T}(; maxiter=100, maxsubiter=200, tol=cbrt(eps(T)),
+                tolg=eps(T)^(1/4), update_H=true, verbose=false)
+
+Alternating least squares solved by projected gradient descent (Lin). Both `W`
+and `H` must be initialized before [`solve!`](@ref).
+
+Each outer iteration updates `W` and `H` by an inner projected-gradient solve.
+`maxiter` bounds the outer iterations and `maxsubiter` the inner ones; `tolg` is
+the gradient-norm tolerance (first-order optimality) for the inner solve. `tol`
+is the convergence tolerance on the relative change of `W` and `H`,
+`update_H=false` holds `H` fixed, and `verbose=true` prints per-iteration
+progress.
+
+Reference: C.-J. Lin, "Projected Gradient Methods for Non-negative Matrix
+Factorization," Neural Computation, 19(10):2756-2779, 2007.
+
+# Examples
+
+```jldoctest
+julia> X = rand(8, 6);
+
+julia> W, H = NMF.randinit(X, 3);
+
+julia> r = NMF.solve!(NMF.ALSPGrad{Float64}(maxiter=50, tolg=1.0e-6), X, W, H);
+
+julia> size(r.W), size(r.H)
+((8, 3), (3, 6))
+```
+"""
 struct ALSPGrad{T} <: AbstractNMFAlgorithm
     maxiter::Int      # maximum number of main iterations
     maxsubiter::Int   # maximum number of iterations within a sub-routine

--- a/src/common.jl
+++ b/src/common.jl
@@ -22,13 +22,84 @@ end
     AbstractNMFAlgorithm
 
 Supertype for NMF algorithm specifications. Each concrete subtype bundles the
-options for one factorization algorithm; an instance is run with `solve!`.
+options for one factorization algorithm; construct an instance of a concrete
+subtype and run it with [`solve!`](@ref).
+
+Concrete subtypes: [`MultUpdate`](@ref), [`ProjectedALS`](@ref),
+[`ALSPGrad`](@ref), [`CoordinateDescent`](@ref), [`GreedyCD`](@ref), and
+[`SPA`](@ref).
+
+# Examples
+
+```jldoctest
+julia> X = rand(8, 6);
+
+julia> W, H = NMF.randinit(X, 3);
+
+julia> r = NMF.solve!(NMF.GreedyCD{Float64}(maxiter=100), X, W, H);
+
+julia> size(r.W), size(r.H)
+((8, 3), (3, 6))
+```
 """
 abstract type AbstractNMFAlgorithm end
+
+"""
+    solve!(alg::AbstractNMFAlgorithm, X, W, H; io=stdout, rng=default_rng()) -> Result
+
+Factorize `X ≈ W*H` using algorithm `alg`, updating `W` and `H` in place and
+returning a [`Result`](@ref).
+
+`W` and `H` must be preallocated to sizes `(p, k)` and `(k, n)`, where `X` is
+`p×n` and `k` is the rank, and must already be initialized (see
+[`randinit`](@ref), [`nndsvd`](@ref), and [`spa`](@ref)). Some algorithms
+require both `W` and `H` to be initialized (e.g. [`MultUpdate`](@ref)); others
+need only `W` (e.g. [`ProjectedALS`](@ref)). Progress is written to `io` when
+`alg` is constructed with `verbose=true`, and `rng` supplies any randomness the
+algorithm uses.
+
+# Examples
+
+```jldoctest
+julia> X = rand(8, 6);
+
+julia> W, H = NMF.randinit(X, 3);
+
+julia> r = NMF.solve!(NMF.MultUpdate{Float64}(maxiter=50), X, W, H);
+
+julia> size(r.W), size(r.H)
+((8, 3), (3, 6))
+```
+"""
+function solve! end
 
 
 # the result type
 
+"""
+    Result{T}
+
+The value returned by [`nnmf`](@ref) and [`solve!`](@ref), holding a
+factorization `X ≈ W*H` together with metadata about the run.
+
+# Fields
+- `W::Matrix{T}`: the `p×k` left factor.
+- `H::Matrix{T}`: the `k×n` right factor.
+- `niters::Int`: number of iterations performed.
+- `converged::Bool`: whether the algorithm reached its convergence tolerance.
+- `objvalue::T`: objective value at the final iteration.
+
+# Examples
+
+```jldoctest
+julia> X = rand(8, 6);
+
+julia> r = nnmf(X, 3);
+
+julia> size(r.W), size(r.H)
+((8, 3), (3, 6))
+```
+"""
 struct Result{T}
     W::Matrix{T}
     H::Matrix{T}

--- a/src/coorddesc.jl
+++ b/src/coorddesc.jl
@@ -21,6 +21,39 @@
 #  computer sciences 92.3: 708-721, 2009.
 
 
+"""
+    CoordinateDescent{T}(; maxiter=100, tol=cbrt(eps(T)), update_H=true,
+                         α=zero(T), l₁ratio=zero(T), regularization=:both,
+                         shuffle=false, verbose=false)
+
+Coordinate-descent solver using Fast Hierarchical Alternating Least Squares
+(Cichocki & Phan), following the scikit-learn implementation.
+
+`α` scales the regularization terms and `l₁ratio ∈ [0, 1]` mixes the L1 and L2
+penalties. `regularization` selects what the penalty applies to: `:components`
+(`H`), `:transformation` (`W`), `:both`, or `:none`. Set `shuffle=true` to
+randomize the coordinate order on each sweep. `maxiter` bounds the iterations,
+`tol` is the convergence tolerance on the relative change of `W` and `H`,
+`update_H=false` holds `H` fixed, and `verbose=true` prints per-iteration
+progress.
+
+Reference: A. Cichocki and A.-H. Phan, "Fast local algorithms for large scale
+nonnegative matrix and tensor factorizations," IEICE Transactions on
+Fundamentals, 92-A(3):708-721, 2009.
+
+# Examples
+
+```jldoctest
+julia> X = rand(8, 6);
+
+julia> W, H = NMF.randinit(X, 3);
+
+julia> r = NMF.solve!(NMF.CoordinateDescent{Float64}(maxiter=50, α=0.5, l₁ratio=0.5), X, W, H);
+
+julia> size(r.W), size(r.H)
+((8, 3), (3, 6))
+```
+"""
 struct CoordinateDescent{T} <: AbstractNMFAlgorithm
     maxiter::Int           # maximum number of iterations (in main procedure)
     verbose::Bool          # whether to show procedural information

--- a/src/greedycd.jl
+++ b/src/greedycd.jl
@@ -7,6 +7,35 @@
 #  the 17th ACM SIGKDD International Conference on Knowledge Discovery and Data Mining, 
 #  pp. 1064–1072, 2011.
 
+"""
+    GreedyCD{T}(; maxiter=100, tol=cbrt(eps(T)), update_H=true,
+                lambda_w=zero(T), lambda_h=zero(T), verbose=false)
+
+Greedy coordinate-descent algorithm with variable selection (Hsieh & Dhillon).
+Both `W` and `H` must be initialized before [`solve!`](@ref).
+
+`lambda_w` and `lambda_h` are L1 regularization coefficients for `W` and `H`.
+`maxiter` bounds the iterations, `tol` is the convergence tolerance on the
+relative change of `W` and `H`, `update_H=false` holds `H` fixed, and
+`verbose=true` prints per-iteration progress.
+
+Reference: C.-J. Hsieh and I. S. Dhillon, "Fast coordinate descent methods with
+variable selection for non-negative matrix factorization," Proc. 17th ACM
+SIGKDD, 1064-1072, 2011.
+
+# Examples
+
+```jldoctest
+julia> X = rand(8, 6);
+
+julia> W, H = NMF.randinit(X, 3);
+
+julia> r = NMF.solve!(NMF.GreedyCD{Float64}(maxiter=50), X, W, H);
+
+julia> size(r.W), size(r.H)
+((8, 3), (3, 6))
+```
+"""
 struct GreedyCD{T} <: AbstractNMFAlgorithm
     maxiter::Int           # maximum number of iterations (in main procedure)
     verbose::Bool          # whether to show procedural information

--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -12,6 +12,29 @@ function randinit(nrows::Integer, ncols::Integer, k::Integer, T::DataType;
     return W, H
 end
 
+"""
+    randinit(X, k; normalize=false, zeroh=false, rng=default_rng()) -> (W, H)
+
+Randomly initialize the factors for a rank-`k` factorization of `X`. For `X` of
+size `(p, n)`, returns `W` of size `(p, k)` and `H` of size `(k, n)` filled with
+uniform random values.
+
+If `normalize=true`, each column of `W` is scaled to sum to one. If
+`zeroh=true`, `H` is returned as a zero matrix, appropriate for algorithms that
+need only `W` initialized (e.g. [`ProjectedALS`](@ref)). `rng` supplies the
+randomness.
+
+# Examples
+
+```jldoctest
+julia> X = rand(10, 7);
+
+julia> W, H = NMF.randinit(X, 3);
+
+julia> size(W), size(H)
+((10, 3), (3, 7))
+```
+"""
 function randinit(X, k::Integer; normalize::Bool=false, zeroh::Bool=false, rng::AbstractRNG=default_rng())
     Base.require_one_based_indexing(X)
     p, n = size(X)
@@ -86,6 +109,34 @@ function _rsvd(rng::AbstractRNG, X, k::Integer)
     return (Q * S.U)[:, 1:k], S.S[1:k], (S.Vt[1:k, :])'
 end
 
+"""
+    nndsvd(X, k; variant=:std, zeroh=false, initdata=nothing, rng=default_rng()) -> (W, H)
+
+Initialize the rank-`k` factors of `X` with Non-Negative Double Singular Value
+Decomposition (NNDSVD). For `X` of size `(p, n)`, returns `W` of size `(p, k)`
+and `H` of size `(k, n)`.
+
+`variant` selects the flavor: `:std` (standard, yields a sparse `W`), `:a`
+(NNDSVDa), or `:ar` (NNDSVDar, recommended for dense NMF). If `zeroh=true`, `H`
+is returned as a zero matrix, appropriate for algorithms that need only `W`
+initialized. By default the required SVD is computed with a randomized algorithm
+seeded by `rng`; pass a precomputed factorization as `initdata` (e.g.
+`initdata=svd(X)`) to use it instead.
+
+Reference: C. Boutsidis and E. Gallopoulos, "SVD based initialization: A head
+start for nonnegative matrix factorization," Pattern Recognition, 2008.
+
+# Examples
+
+```jldoctest
+julia> X = rand(10, 7);
+
+julia> W, H = NMF.nndsvd(X, 3; variant=:ar);
+
+julia> size(W), size(H)
+((10, 3), (3, 7))
+```
+"""
 function nndsvd(X, k::Integer; zeroh::Bool=false, variant::Symbol=:std, initdata=nothing,
                 rng::AbstractRNG=default_rng())
 

--- a/src/interf.jl
+++ b/src/interf.jl
@@ -1,5 +1,46 @@
 # Interface function: nnmf
 
+"""
+    nnmf(X, k; init=:nndsvdar, alg=:greedycd, maxiter=100, tol=…, kwargs...) -> Result
+
+Factorize the non-negative matrix `X` into a product `W*H` of two non-negative
+matrices, where `W` has `k` columns and `H` has `k` rows, so that `W*H`
+approximates `X`. `X` is `p×n`, `W` is `p×k`, and `H` is `k×n`; `k` must not
+exceed `min(p, n)`. The factors are initialized and then optimized, and the
+[`Result`](@ref) is returned.
+
+# Keyword arguments
+- `init::Symbol=:nndsvdar`: initialization method, one of `:random`, `:nndsvd`,
+  `:nndsvda`, `:nndsvdar`, `:spa`, or `:custom` (supply `W0` and `H0`).
+- `initdata=nothing`: for the `:nndsvd` variants, a precomputed SVD of `X`
+  (e.g. `svd(X)`) to use in place of an internally computed randomized SVD.
+- `alg::Symbol=:greedycd`: factorization algorithm, one of `:multmse`,
+  `:multdiv`, `:projals`, `:alspgrad`, `:cd`, `:greedycd`, or `:spa`. Selecting
+  `:spa` requires `init=:spa`.
+- `maxiter::Integer=100`: maximum number of iterations.
+- `tol::Real=cbrt(eps(eltype(X))/100)`: convergence tolerance on the relative
+  change of `W` and `H`.
+- `replicates::Integer=1`: number of runs from independent random
+  initializations; the result with the smallest objective value is returned.
+- `W0`, `H0`: custom initial factors, required (and used) only when
+  `init=:custom`. They may be overwritten; pass copies to preserve them.
+- `update_H::Bool=true`: if `false`, hold `H` fixed and update only `W`.
+- `verbose::Bool=false`: whether to print per-iteration progress.
+- `io::IO=stdout`: stream for progress output when `verbose=true`.
+- `rng::AbstractRNG=default_rng()`: random number generator for initialization
+  and any randomized algorithm steps.
+
+# Examples
+
+```jldoctest
+julia> X = rand(8, 6);
+
+julia> r = nnmf(X, 3; alg=:multmse, maxiter=50, tol=1.0e-4);
+
+julia> size(r.W), size(r.H)
+((8, 3), (3, 6))
+```
+"""
 function nnmf(X::AbstractMatrix{T}, k::Integer;
               init::Symbol=:nndsvdar,
               initdata=nothing,

--- a/src/multupd.jl
+++ b/src/multupd.jl
@@ -6,6 +6,35 @@
 #   Matrix Factorization. Advances in NIPS, 2001.
 #
 
+"""
+    MultUpdate{T}(; obj=:mse, maxiter=100, tol=cbrt(eps(T)), update_H=true,
+                  lambda_w=zero(T), lambda_h=zero(T), verbose=false)
+
+Multiplicative-update algorithm (Lee & Seung). Both `W` and `H` must be
+initialized before [`solve!`](@ref).
+
+`obj` selects the objective: `:mse` (mean squared error) or `:div` (divergence).
+`lambda_w` and `lambda_h` are L1 regularization coefficients for `W` and `H`.
+`maxiter` bounds the iterations, `tol` is the convergence tolerance on the
+relative change of `W` and `H`, `update_H=false` holds `H` fixed, and
+`verbose=true` prints per-iteration progress.
+
+Reference: D. D. Lee and H. S. Seung, "Algorithms for Non-negative Matrix
+Factorization," Advances in NIPS, 2001.
+
+# Examples
+
+```jldoctest
+julia> X = rand(8, 6);
+
+julia> W, H = NMF.randinit(X, 3);
+
+julia> r = NMF.solve!(NMF.MultUpdate{Float64}(obj=:mse, maxiter=50), X, W, H);
+
+julia> size(r.W), size(r.H)
+((8, 3), (3, 6))
+```
+"""
 struct MultUpdate{T} <: AbstractNMFAlgorithm
     obj::Symbol                 # objective :mse or :div
     maxiter::Int                # maximum number of iterations

--- a/src/projals.jl
+++ b/src/projals.jl
@@ -12,6 +12,32 @@
 #  negative entries back to zeros.
 #
 
+"""
+    ProjectedALS{T}(; maxiter=100, tol=cbrt(eps(T)), update_H=true,
+                    lambda_w=cbrt(eps(T)), lambda_h=cbrt(eps(T)), verbose=false)
+
+Naive projected alternating least squares. Each iteration solves for `W` or `H`
+by unconstrained least squares and then clamps negative entries to zero. Only
+`W` needs to be initialized before [`solve!`](@ref).
+
+`lambda_w` and `lambda_h` are L2 regularization coefficients for `W` and `H`.
+`maxiter` bounds the iterations, `tol` is the convergence tolerance on the
+relative change of `W` and `H`, `update_H=false` holds `H` fixed, and
+`verbose=true` prints per-iteration progress.
+
+# Examples
+
+```jldoctest
+julia> X = rand(8, 6);
+
+julia> W, H = NMF.randinit(X, 3);
+
+julia> r = NMF.solve!(NMF.ProjectedALS{Float64}(maxiter=50), X, W, H);
+
+julia> size(r.W), size(r.H)
+((8, 3), (3, 6))
+```
+"""
 struct ProjectedALS{T} <: AbstractNMFAlgorithm
     maxiter::Int            # maximum number of iterations (in main procedure)
     verbose::Bool           # whether to show procedural information

--- a/src/spa.jl
+++ b/src/spa.jl
@@ -5,6 +5,34 @@
 #   IEEE Transactions on Pattern Analysis and Machine Intelligence, 
 #   vol. 36, no. 4, pp. 698-714, 2013. 
 
+"""
+    SPA(; obj=:mse)
+
+Successive Projection Algorithm for separable NMF (Gillis & Vavasis). Intended
+for use with `W` and `H` produced by [`spa`](@ref) initialization: passing this
+to [`solve!`](@ref) assembles the [`Result`](@ref) and its objective value
+without further iterating.
+
+`obj` selects the reported objective: `:mse` (mean squared error) or `:div`
+(divergence).
+
+Reference: N. Gillis and S. A. Vavasis, "Fast and robust recursive algorithms
+for separable nonnegative matrix factorization," IEEE Transactions on Pattern
+Analysis and Machine Intelligence, 36(4):698-714, 2014.
+
+# Examples
+
+```jldoctest
+julia> X = rand(8, 6);
+
+julia> W, H = NMF.spa(X, 3);
+
+julia> r = NMF.solve!(NMF.SPA(obj=:mse), X, W, H);
+
+julia> size(r.W), size(r.H)
+((8, 3), (3, 6))
+```
+"""
 struct SPA <: AbstractNMFAlgorithm
     obj::Symbol   # objective :mse or :div
 
@@ -15,6 +43,34 @@ struct SPA <: AbstractNMFAlgorithm
 end
 
 # initialization
+"""
+    spa(X, k; nnls_alg=(:pivot, :cache)) -> (W, H)
+
+Initialize the rank-`k` factors of `X` with the Successive Projection Algorithm
+(SPA) for separable NMF. For `X` of size `(p, n)`, returns `W` of size `(p, k)`
+and `H` of size `(k, n)`. `W` collects `k` "anchor" columns of `X` selected by
+successive orthogonal projection, and `H` is obtained by non-negative least
+squares.
+
+Every column of `X` must have a nonzero sum, since the columns are normalized to
+sum to one before anchor selection. `nnls_alg` is the `(alg, variant)` pair
+forwarded to `NonNegLeastSquares.nonneg_lsq` when solving for `H`.
+
+Reference: N. Gillis and S. A. Vavasis, "Fast and robust recursive algorithms
+for separable nonnegative matrix factorization," IEEE Transactions on Pattern
+Analysis and Machine Intelligence, 36(4):698-714, 2014.
+
+# Examples
+
+```jldoctest
+julia> X = rand(10, 7);
+
+julia> W, H = NMF.spa(X, 3);
+
+julia> size(W), size(H)
+((10, 3), (3, 7))
+```
+"""
 function spa(X::AbstractMatrix{T}, k::Integer; nnls_alg::Tuple{Symbol, Symbol}=(:pivot, :cache)) where T
 
     Base.require_one_based_indexing(X)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using Random
 using LinearAlgebra
 using StatsBase
 using Aqua
+using Documenter
 using ExplicitImports
 using OffsetArrays
 
@@ -22,6 +23,10 @@ println("Running tests:")
 @testset "All tests" begin
     @testset "Aqua" begin
         Aqua.test_all(NMF)
+    end
+    @testset "Doctests" begin
+        DocMeta.setdocmeta!(NMF, :DocTestSetup, :(using NMF); recursive=true)
+        doctest(NMF; manual=false)
     end
     @testset "ExplicitImports" begin
         # The public-ness checks rely on `Base.ispublic`, available only on


### PR DESCRIPTION
Document nnmf, Result, solve!, the initialization functions
(randinit, nndsvd, spa), and every algorithm struct (MultUpdate,
ProjectedALS, ALSPGrad, CoordinateDescent, GreedyCD, SPA), plus a
module docstring. Correct the AbstractNMFAlgorithm docstring, which
described instantiating the abstract type directly.

Every docstring example is a jldoctest; add Documenter as a test
dependency and run doctest(NMF; manual=false) from the test suite so
the examples stay correct.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
